### PR TITLE
Remove redefinition of IFNAMSIZ

### DIFF
--- a/itl80211/linux/types.h
+++ b/itl80211/linux/types.h
@@ -30,8 +30,6 @@
 #define local_bh_disable()
 #define local_bh_enable()
 
-#define IFNAMSIZ 32
-
 #define NUM_DEFAULT_KEYS 4
 #define NUM_DEFAULT_MGMT_KEYS 2
 


### PR DESCRIPTION
IFNAMSIZ is defined in `net/if.h` of system headers with value 16. Defining it to 32 here confuses `struct ifnet` layout - it becomes different in `mac80211.cpp` and `_mbuf.cpp` files.