### PR TITLE
Fix "Release" builds

### DIFF
--- a/itlwm.xcodeproj/project.pbxproj
+++ b/itlwm.xcodeproj/project.pbxproj
@@ -1345,6 +1345,7 @@
 				MARKETING_VERSION = 1.1.0;
 				MODULE_NAME = com.zxystd.itlwmx;
 				MODULE_VERSION = "$(MARKETING_VERSION)";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwmx;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.12;
@@ -1372,6 +1373,7 @@
 				MARKETING_VERSION = 1.1.0;
 				MODULE_NAME = com.zxystd.itlwmx;
 				MODULE_VERSION = "$(MARKETING_VERSION)";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwmx;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.12;

--- a/itlwm.xcodeproj/project.pbxproj
+++ b/itlwm.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 				MARKETING_VERSION = 1.1.0;
 				MODULE_NAME = com.zxystd.itlwm;
 				MODULE_VERSION = "$(MARKETING_VERSION)";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.12;
@@ -1293,6 +1294,7 @@
 				MARKETING_VERSION = 1.1.0;
 				MODULE_NAME = com.zxystd.itlwm;
 				MODULE_VERSION = "$(MARKETING_VERSION)";
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.12;


### PR DESCRIPTION
Hi!
Whenever a new itlwm commit comes out, in order to create not a Debug build but a Release one, I need to change the "Build Active Architecture Only" parameter on the target settings.
So, this PR does that job. It's a simple one haha
Thank you!