### PR TITLE
Add auth security info to ioctl_sta_info for HeliPort issue #181

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -18,7 +18,7 @@
 #include "IoctlId.h"
 
 #define IOCTL_MASK 0x800000
-#define IOCTL_VERSION 1
+#define IOCTL_VERSION 2
 #define NWID_LEN 32
 #define WPA_KEY_LEN 128
 
@@ -52,6 +52,8 @@ struct ioctl_sta_info {
     uint rate;
     unsigned char ssid[NWID_LEN];
     uint8_t bssid[ETHER_ADDR_LEN];
+    unsigned int supported_rsnprotos;   //itl80211_proto
+    unsigned int rsn_akms;              //rsn_akms
 };
 
 struct ioctl_power {

--- a/itlwm/ItlNetworkUserClient.cpp
+++ b/itlwm/ItlNetworkUserClient.cpp
@@ -127,6 +127,8 @@ sSTA_INFO(OSObject* target, void* data, bool isSet)
     st->rssi = -(0 - IWM_MIN_DBM - ic_bss->ni_rssi);
     st->noise = that->fSoft->sc_noise;
     st->rate = ic_bss->ni_rates.rs_rates[ic_bss->ni_txrate];
+    st->supported_rsnprotos = ic->ic_bss->ni_supported_rsnprotos;
+    st->rsn_akms = ic->ic_bss->ni_rsnakms;
     memset(st->ssid, 0, sizeof(st->ssid));
     bcopy(ic->ic_des_essid, st->ssid, ic->ic_des_esslen);
     memset(st->bssid, 0, sizeof(st->bssid));

--- a/itlwmx/ItlNetworkUserClient.cpp
+++ b/itlwmx/ItlNetworkUserClient.cpp
@@ -127,6 +127,8 @@ sSTA_INFO(OSObject* target, void* data, bool isSet)
     st->rssi = -(0 - IWX_MIN_DBM - ic_bss->ni_rssi);
     st->noise = that->fSoft->sc_noise;
     st->rate = ic_bss->ni_rates.rs_rates[ic_bss->ni_txrate];
+    st->supported_rsnprotos = ic->ic_bss->ni_supported_rsnprotos;
+    st->rsn_akms = ic->ic_bss->ni_rsnakms;
     memset(st->ssid, 0, sizeof(st->ssid));
     bcopy(ic->ic_des_essid, st->ssid, ic->ic_des_esslen);
     memset(st->bssid, 0, sizeof(st->bssid));


### PR DESCRIPTION
This PR is for https://github.com/OpenIntelWireless/HeliPort/issues/181

TL;DR is that for currently connected network, we don't have the security info for the network lock icon to be displayed in the UI.  This PR adds the necessary info to ioctl_sta_info to be used by HeliPort
