### PR TITLE
Use Apple RSN supplicant

### DIFF
--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -115,13 +115,12 @@ IONetworkInterface *AirportItlwm::createInterface()
     return netif;
 }
 
-void AirportItlwm::associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct ether_addr &bssid, uint32_t authtype_lower, uint32_t authtype_upper, uint8_t *key, uint32_t key_len, int key_index) {
+void AirportItlwm::associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct ether_addr &bssid, uint32_t authtype_lower, uint32_t authtype_upper, uint8_t *key, uint32_t key_len, int key_index) 
+{
     struct ieee80211com *ic = fHalService->get80211Controller();
     
     ieee80211_disable_rsn(ic);
     ieee80211_disable_wep(ic);
-    ic->ic_flags &= ~IEEE80211_F_PSK;
-    bzero(ic->ic_psk, sizeof(ic->ic_psk));		
     
     struct ieee80211_wpaparams	 wpa;
     struct ieee80211_nwkey		 nwkey;

--- a/AirportItlwm/AirportItlwm.hpp
+++ b/AirportItlwm/AirportItlwm.hpp
@@ -73,7 +73,9 @@ public:
                                OSData *                data         = 0) override;
     
     void releaseAll();
-    void associateSSID(const char *ssid, uint8_t *key, uint16_t keyLen);
+    void associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct ether_addr &bssid, uint32_t authtype_lower, uint32_t authtype_upper, uint8_t *key, uint32_t key_len, int key_index);
+    void setPTK(const u_int8_t *key, size_t key_len);
+    void setGTK(const u_int8_t *key, size_t key_len, u_int8_t kid, u_int8_t *rsc);
     void watchdogAction(IOTimerEventSource *timer);
     bool initPCIPowerManagment(IOPCIDevice *provider);
     static IOReturn tsleepHandler(OSObject* owner, void* arg0 = 0, void* arg1 = 0, void* arg2 = 0, void* arg3 = 0);
@@ -128,6 +130,7 @@ public:
     FUNC_IOCTL_GET(DRIVER_VERSION, apple80211_version_data)
     FUNC_IOCTL_GET(HARDWARE_VERSION, apple80211_version_data)
     FUNC_IOCTL(RSN_IE, apple80211_rsn_ie_data)
+	FUNC_IOCTL_GET(AP_IE_LIST, apple80211_ap_ie_data)
     FUNC_IOCTL_GET(ASSOCIATION_STATUS, apple80211_assoc_status_data)
     FUNC_IOCTL_GET(COUNTRY_CODE, apple80211_country_code_data)
     FUNC_IOCTL_GET(RADIO_INFO, apple80211_radio_info_data)

--- a/AirportItlwm/AirportItlwm.hpp
+++ b/AirportItlwm/AirportItlwm.hpp
@@ -120,6 +120,7 @@ public:
     FUNC_IOCTL(POWER, apple80211_power_data)
     FUNC_IOCTL_SET(ASSOCIATE, apple80211_assoc_data)
     FUNC_IOCTL_GET(ASSOCIATE_RESULT, apple80211_assoc_result_data)
+    IOReturn setDISASSOCIATE(OSObject *);
     FUNC_IOCTL_GET(RATE_SET, apple80211_rate_set_data)
     FUNC_IOCTL_GET(MCS_INDEX_SET, apple80211_mcs_index_set_data)
     FUNC_IOCTL_GET(SUPPORTED_CHANNELS, apple80211_sup_channel_data)
@@ -130,7 +131,7 @@ public:
     FUNC_IOCTL_GET(DRIVER_VERSION, apple80211_version_data)
     FUNC_IOCTL_GET(HARDWARE_VERSION, apple80211_version_data)
     FUNC_IOCTL(RSN_IE, apple80211_rsn_ie_data)
-	FUNC_IOCTL_GET(AP_IE_LIST, apple80211_ap_ie_data)
+    FUNC_IOCTL_GET(AP_IE_LIST, apple80211_ap_ie_data)
     FUNC_IOCTL_GET(ASSOCIATION_STATUS, apple80211_assoc_status_data)
     FUNC_IOCTL_GET(COUNTRY_CODE, apple80211_country_code_data)
     FUNC_IOCTL_GET(RADIO_INFO, apple80211_radio_info_data)

--- a/AirportItlwm/AirportItlwmInterface.cpp
+++ b/AirportItlwm/AirportItlwmInterface.cpp
@@ -11,8 +11,28 @@
 #define super IO80211Interface
 OSDefineMetaClassAndStructors(AirportItlwmInterface, IO80211Interface);
 
+const char* hexdump(uint8_t *buf, size_t len) {
+    ssize_t str_len = len * 3 + 1;
+    char *str = (char*)IOMalloc(str_len);
+    if (!str)
+        return nullptr;
+    for (size_t i = 0; i < len; i++)
+    snprintf(str + 3 * i, (len - i) * 3, "%02x ", buf[i]);
+    str[MAX(str_len - 2, 0)] = 0;
+    return str;
+}
+
 UInt32 AirportItlwmInterface::
 inputPacket(mbuf_t packet, UInt32 length, IOOptionBits options, void *param)
 {
+    uint16_t ether_type;
+    size_t len = mbuf_len(packet);
+    if (len >= 14 && mbuf_copydata(packet, 12, 2, &ether_type) == 0 && ether_type == _OSSwapInt16(ETHERTYPE_PAE)) { // EAPOL packet
+        const char* dump = hexdump((uint8_t*)mbuf_data(packet), len);
+        IOLog("itlwm: input EAPOL packet, len: %zu, data: %s\n", len, dump ? dump : "Failed to allocate memory");
+        if (dump)
+            IOFree((void*)dump, 3 * len + 1);
+        return IO80211Interface::inputPacket(packet, (UInt32)len, 0, param);
+    }
     return IOEthernetInterface::inputPacket(packet, length, options, param);
 }

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -80,8 +80,12 @@ SInt32 AirportItlwm::apple80211Request(unsigned int request_type,
         case APPLE80211_IOC_ASSOCIATE:  // 20
             IOCTL_SET(request_type, ASSOCIATE, apple80211_assoc_data);
             break;
-        case APPLE80211_IOC_ASSOCIATE_RESULT:
+        case APPLE80211_IOC_ASSOCIATE_RESULT: // 21
             IOCTL_GET(request_type, ASSOCIATE_RESULT, apple80211_assoc_result_data);
+            break;
+        case APPLE80211_IOC_DISASSOCIATE: // 22
+            if (request_type == SIOCSA80211)
+                setDISASSOCIATE(interface);
             break;
         case APPLE80211_IOC_RATE_SET:
             IOCTL_GET(request_type, RATE_SET, apple80211_rate_set_data);
@@ -646,6 +650,18 @@ getASSOCIATE_RESULT(OSObject *object, struct apple80211_assoc_result_data *ad)
         return kIOReturnSuccess;
     }
     return kIOReturnError;
+}
+
+IOReturn AirportItlwm::setDISASSOCIATE(OSObject *object)
+{
+    XYLog("%s\n", __FUNCTION__);
+    struct ieee80211com *ic = fHalService->get80211Controller();
+    
+    ieee80211_del_ess(ic, nullptr, 0, 1);
+    ieee80211_deselect_ess(ic);
+    // ic->ic_rsn_ie_override[1] = 0;
+    ieee80211_new_state(ic, IEEE80211_S_SCAN, -1);
+    return kIOReturnSuccess;
 }
 
 IOReturn AirportItlwm::

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -10,6 +10,8 @@
 
 extern IOCommandGate *_fCommandGate;
 
+const char* hexdump(uint8_t *buf, size_t len);
+
 SInt32 AirportItlwm::apple80211Request(unsigned int request_type,
                                        int request_number,
                                        IO80211Interface *interface,
@@ -19,7 +21,6 @@ SInt32 AirportItlwm::apple80211Request(unsigned int request_type,
         return kIOReturnError;
     }
     IOReturn ret = kIOReturnError;
-    bool isGet = (request_type == SIOCGA80211);
     
     switch (request_number) {
         case APPLE80211_IOC_SSID:  // 1
@@ -110,8 +111,11 @@ SInt32 AirportItlwm::apple80211Request(unsigned int request_type,
         case APPLE80211_IOC_HARDWARE_VERSION:  // 44
             IOCTL_GET(request_type, HARDWARE_VERSION, apple80211_version_data);
             break;
-        case APPLE80211_IOC_RSN_IE:
+        case APPLE80211_IOC_RSN_IE: // 46
             IOCTL(request_type, RSN_IE, apple80211_rsn_ie_data);
+            break;
+        case APPLE80211_IOC_AP_IE_LIST: // 48
+            IOCTL_GET(request_type, AP_IE_LIST, apple80211_ap_ie_data);
             break;
         case APPLE80211_IOC_ASSOCIATION_STATUS:  // 50
             IOCTL_GET(request_type, ASSOCIATION_STATUS, apple80211_assoc_status_data);
@@ -199,9 +203,55 @@ setAUTH_TYPE(OSObject *object, struct apple80211_authtype_data *ad)
 }
 
 IOReturn AirportItlwm::
-setCIPHER_KEY(OSObject *object, struct apple80211_key *ck)
+setCIPHER_KEY(OSObject *object, struct apple80211_key *key)
 {
     XYLog("%s", __FUNCTION__);
+    const char* keydump = hexdump(key->key, key->key_len);
+    const char* rscdump = hexdump(key->key_rsc, key->key_rsc_len);
+    const char* eadump = hexdump(key->key_ea.octet, APPLE80211_ADDR_LEN);
+    if (keydump && rscdump && eadump)
+        XYLog("Set key request: len=%d cipher_type=%d flags=%d index=%d key=%s rsc_len=%d rsc=%s ea=%s\n",
+              key->key_len, key->key_cipher_type, key->key_flags, key->key_index, keydump, key->key_rsc_len, rscdump, eadump);
+    else
+        XYLog("Set key request, but failed to allocate memory for hexdump\n");
+    
+    if (keydump)
+        IOFree((void*)keydump, 3 * key->key_len + 1);
+    if (rscdump)
+        IOFree((void*)rscdump, 3 * key->key_rsc_len + 1);
+    if (eadump)
+        IOFree((void*)eadump, 3 * APPLE80211_ADDR_LEN + 1);
+    
+    switch (key->key_cipher_type) {
+        case APPLE80211_CIPHER_NONE:
+            XYLog("Setting NONE key is not supported\n");
+            break;
+        case APPLE80211_CIPHER_WEP_40:
+        case APPLE80211_CIPHER_WEP_104:
+            XYLog("Setting WEP key %d is not supported\n", key->key_index);
+            break;
+        case APPLE80211_CIPHER_TKIP:
+        case APPLE80211_CIPHER_AES_OCB:
+        case APPLE80211_CIPHER_AES_CCM:
+            switch (key->key_flags) {
+                case 4: // PTK
+                    setPTK(key->key, key->key_len);
+                    getNetworkInterface()->postMessage(APPLE80211_M_RSN_HANDSHAKE_DONE);
+                    break;
+                case 0: // GTK
+                    setGTK(key->key, key->key_len, key->key_index, key->key_rsc);
+                    getNetworkInterface()->postMessage(APPLE80211_M_RSN_HANDSHAKE_DONE);
+                    break;
+            }
+            break;
+        case APPLE80211_CIPHER_PMK:
+            XYLog("Setting WPA PMK is not supported\n");
+            break;
+        case APPLE80211_CIPHER_PMKSA:
+            XYLog("Setting WPA PMKSA is not supported\n");
+            break;
+    }
+    //fInterface->postMessage(APPLE80211_M_CIPHER_KEY_CHANGED);
     return kIOReturnSuccess;
 }
 
@@ -498,6 +548,19 @@ setRSN_IE(OSObject *object, struct apple80211_rsn_ie_data *data)
 }
 
 IOReturn AirportItlwm::
+getAP_IE_LIST(OSObject *object, struct apple80211_ap_ie_data *data)
+{
+    struct ieee80211com *ic = fHalService->get80211Controller();
+    if (ic->ic_bss == NULL || ic->ic_bss->ni_rsnie_tlv == NULL || ic->ic_bss->ni_rsnie_tlv_len > data->len) {
+        return kIOReturnError;
+    }
+    data->version = APPLE80211_VERSION;
+    data->len = ic->ic_bss->ni_rsnie_tlv_len;
+    memcpy(data->ie_data, ic->ic_bss->ni_rsnie_tlv, data->len);
+    return kIOReturnSuccess;
+}
+
+IOReturn AirportItlwm::
 getNOISE(OSObject *object,
                          struct apple80211_noise_data *nd)
 {
@@ -567,7 +630,7 @@ setASSOCIATE(OSObject *object,
     XYLog("%s [%s]\n", __FUNCTION__, ad->ad_ssid);
     this->current_authtype_lower = ad->ad_auth_lower;
     this->current_authtype_upper = ad->ad_auth_upper;
-    associateSSID((const char *)ad->ad_ssid, ad->ad_key.key, ad->ad_key.key_len);
+    associateSSID(ad->ad_ssid, ad->ad_ssid_len, ad->ad_bssid, ad->ad_auth_lower, ad->ad_auth_upper, ad->ad_key.key, ad->ad_key.key_len, ad->ad_key.key_index);
     return kIOReturnSuccess;
 }
 

--- a/include/Airport/apple80211_ioctl.h
+++ b/include/Airport/apple80211_ioctl.h
@@ -557,10 +557,12 @@ struct apple80211_assoc_data
     u_int8_t                ad_ssid[ APPLE80211_MAX_SSID_LEN ];
     struct ether_addr        ad_bssid;        // prefer over ssid if not zeroed
     struct apple80211_key    ad_key;
-    u_int16_t                ad_rsn_ie_len;
+    u_int8_t                unknown[82];
     u_int8_t                ad_rsn_ie[ APPLE80211_MAX_RSN_IE_LEN ];
     u_int32_t                ad_flags;        // apple80211_assoc_flags
 };
+
+static_assert(offsetof(apple80211_assoc_data, ad_rsn_ie) == 206, "offsetof(apple80211_assoc_data, ad_rsn_ie)");
 
 struct apple80211_deauth_data
 {

--- a/include/Airport/apple80211_var.h
+++ b/include/Airport/apple80211_var.h
@@ -133,14 +133,17 @@ enum apple80211_authtype_lower
 
 enum apple80211_authtype_upper
 {
-    APPLE80211_AUTHTYPE_NONE        = 0,    //    No upper auth
-    APPLE80211_AUTHTYPE_WPA            = 1,    //    WPA
-    APPLE80211_AUTHTYPE_WPA_PSK        = 2,    //    WPA PSK
-    APPLE80211_AUTHTYPE_WPA2        = 3,    //    WPA2
-    APPLE80211_AUTHTYPE_WPA2_PSK    = 4,    //    WPA2 PSK
-    APPLE80211_AUTHTYPE_LEAP        = 5,    //    LEAP
-    APPLE80211_AUTHTYPE_8021X        = 6,    //    802.1x
-    APPLE80211_AUTHTYPE_WPS            = 7,    //    WiFi Protected Setup
+    APPLE80211_AUTHTYPE_NONE         = 0,         //    No upper auth
+    APPLE80211_AUTHTYPE_WPA          = 1 << 0,    //    WPA
+    APPLE80211_AUTHTYPE_WPA_PSK      = 1 << 1,    //    WPA PSK
+    APPLE80211_AUTHTYPE_WPA2         = 1 << 2,    //    WPA2
+    APPLE80211_AUTHTYPE_WPA2_PSK     = 1 << 3,    //    WPA2 PSK
+    APPLE80211_AUTHTYPE_LEAP         = 1 << 4,    //    LEAP
+    APPLE80211_AUTHTYPE_8021X        = 1 << 5,    //    802.1x
+    APPLE80211_AUTHTYPE_WPS          = 1 << 6,    //    WiFi Protected Setup
+    APPLE80211_AUTHTYPE_SHA256_PSK   = 1 << 7,
+    APPLE80211_AUTHTYPE_SHA256_8021X = 1 << 8,
+    APPLE80211_AUTHTYPE_WPA3_SAE     = 1 << 9
 };
 
 // Unify association status code and deauth reason codes into a single enum describing
@@ -524,7 +527,7 @@ enum apple80211_card_capability
     APPLE80211_CAP_WOW                = 20,    // CAPABILITY: Wake on wireless
     APPLE80211_CAP_TSN                = 21,    // CAPABILITY: WPA with WEP group key
 };
-#define APPLE80211_CAP_MAX    21
+#define APPLE80211_CAP_MAX    63
 
 enum apple80211_virtual_interface_type
 {
@@ -566,6 +569,25 @@ struct apple80211_status_msg_hdr
 #define APPLE80211_M_COUNTRY_CODE_CHANGED    11
 #define APPLE80211_M_STA_ARRIVE                12
 #define APPLE80211_M_STA_LEAVE                13
+#define APPLE80211_M_DECRYPTION_FAILURE     14
+#define APPLE80211_M_SCAN_CACHE_UPDATED     15
+#define APPLE80211_M_INTERNAL_SCAN_DONE     16
+#define APPLE80211_M_LINK_QUALITY           17
+#define APPLE80211_M_IBSS_PEER_ARRIVED      18
+#define APPLE80211_M_IBSS_PEER_LEFT         19
+#define APPLE80211_M_RSN_HANDSHAKE_DONE     20
+#define APPLE80211_M_BT_COEX_CHANGED        21
+#define APPLE80211_M_P2P_PEER_DETECTED      22
+#define APPLE80211_M_P2P_LISTEN_COMPLETE    23
+#define APPLE80211_M_P2P_SCAN_COMPLETE      24
+#define APPLE80211_M_P2P_LISTEN_STARTED     25
+#define APPLE80211_M_P2P_SCAN_STARTED       26
+#define APPLE80211_M_P2P_INTERFACE_CREATED  27
+#define APPLE80211_M_P2P_GROUP_STARTED      28
+#define APPLE80211_M_BGSCAN_NET_DISCOVERED  29
+#define APPLE80211_M_ROAMED                 30
+#define APPLE80211_M_ACT_FRM_TX_COMPLETE    31
+#define APPLE80211_M_DEAUTH_RECEIVED        32
 #define APPLE80211_M_DRIVER_AVAILABLE           0x37
 #define APPLE80211_M_LINK_ADDRESS_CHANGED       0x3B
 #define APPLE80211_M_ROAM_START                 0x46

--- a/include/HAL/ItlDriverInfo.hpp
+++ b/include/HAL/ItlDriverInfo.hpp
@@ -19,13 +19,15 @@ class ItlDriverInfo {
     
 public:
     
-    virtual char *getFirmwareVersion() = 0;
+    virtual const char *getFirmwareVersion() = 0;
     
     virtual int16_t getBSSNoise() = 0;
     
     virtual bool is5GBandSupport() = 0;
     
     virtual int getTxNSS() = 0;
+    
+    virtual const char *getFirmwareName() = 0;
 };
 
 #endif /* ItlDriverInfo_h */

--- a/itl80211/openbsd/net80211/ieee80211_input.c
+++ b/itl80211/openbsd/net80211/ieee80211_input.c
@@ -1058,7 +1058,11 @@ ieee80211_enqueue_data(struct ieee80211com *ic, mbuf_t m,
             if (ifp->if_bpf && m1 == NULL)
                 bpf_mtap(ifp->if_bpf, m, BPF_DIRECTION_IN);
 #endif
+#ifdef AIRPORT
+            ml_enqueue(ml, m);
+#else
             ieee80211_eapol_key_input(ic, m, ni);
+#endif
         } else {
             ml_enqueue(ml, m);
         }

--- a/itl80211/openbsd/net80211/ieee80211_node.c
+++ b/itl80211/openbsd/net80211/ieee80211_node.c
@@ -339,7 +339,7 @@ ieee80211_ess_setwpaparms(struct ieee80211_ess *ess,
     ess->flags |= IEEE80211_F_RSNON;
     
     if (ess->rsnakms &
-        (IEEE80211_AKM_8021X|IEEE80211_WPA_AKM_SHA256_8021X))
+        (IEEE80211_AKM_8021X|IEEE80211_AKM_SHA256_8021X))
         ess->flags |= IEEE80211_JOIN_8021X;
     
     return ENETRESET;
@@ -1128,30 +1128,36 @@ ieee80211_match_bss(struct ieee80211com *ic, struct ieee80211_node *ni,
     }
     
     if (ic->ic_if.if_flags & IFF_DEBUG && ieee80211_debug) {
-        DPRINTF(("%s: %c %s%c", ic->ic_if.if_xname, fail ? '-' : '+',
+        XYLog("%s: %c %s%c %3d%c %+4d %2dM%c %4s%c %7s%c %3s%c %.*s %s\n",
+              ic->ic_if.if_xname,
+              fail ? '-' : '+',
               ether_sprintf(ni->ni_bssid),
-              fail & IEEE80211_NODE_ASSOCFAIL_BSSID ? '!' : ' '));
-        DPRINTF((" %3d%c", ieee80211_chan2ieee(ic, ni->ni_chan),
-              fail & IEEE80211_NODE_ASSOCFAIL_CHAN ? '!' : ' '));
-        DPRINTF((" %+4d", ni->ni_rssi));
-        DPRINTF((" %2dM%c", (rate & IEEE80211_RATE_VAL) / 2,
-              fail & IEEE80211_NODE_ASSOCFAIL_BASIC_RATE ? '!' : ' '));
-        DPRINTF((" %4s%c",
+              fail & IEEE80211_NODE_ASSOCFAIL_BSSID ? '!' : ' ',
+              
+              ieee80211_chan2ieee(ic, ni->ni_chan),
+              fail & IEEE80211_NODE_ASSOCFAIL_CHAN ? '!' : ' ',
+              
+              ni->ni_rssi,
+              
+              (rate & IEEE80211_RATE_VAL) / 2,
+              fail & IEEE80211_NODE_ASSOCFAIL_BASIC_RATE ? '!' : ' ',
+              
               (ni->ni_capinfo & IEEE80211_CAPINFO_ESS) ? "ess" :
               (ni->ni_capinfo & IEEE80211_CAPINFO_IBSS) ? "ibss" :
               "????",
-              fail & IEEE80211_NODE_ASSOCFAIL_IBSS ? '!' : ' '));
-        DPRINTF((" %7s%c ",
+              fail & IEEE80211_NODE_ASSOCFAIL_IBSS ? '!' : ' ',
+              
               (ni->ni_capinfo & IEEE80211_CAPINFO_PRIVACY) ?
               "privacy" : "no",
-              fail & IEEE80211_NODE_ASSOCFAIL_PRIVACY ? '!' : ' '));
-        DPRINTF((" %3s%c ",
+              fail & IEEE80211_NODE_ASSOCFAIL_PRIVACY ? '!' : ' ',
+              
               (ic->ic_flags & IEEE80211_F_RSNON) ?
               "rsn" : "no",
-              fail & IEEE80211_NODE_ASSOCFAIL_WPA_PROTO ? '!' : ' '));
-        ieee80211_print_essid(ni->ni_essid, ni->ni_esslen);
-        DPRINTF(("%s\n",
-              fail & IEEE80211_NODE_ASSOCFAIL_ESSID ? "!" : ""));
+              fail & IEEE80211_NODE_ASSOCFAIL_WPA_PROTO ? '!' : ' ',
+              
+              ni->ni_esslen + 1,
+              ni->ni_essid,
+              fail & IEEE80211_NODE_ASSOCFAIL_ESSID ? "!" : "");
     }
     
     /* We don't care about unrelated networks during background scans. */

--- a/itl80211/openbsd/net80211/ieee80211_output.c
+++ b/itl80211/openbsd/net80211/ieee80211_output.c
@@ -1445,13 +1445,29 @@ ieee80211_get_assoc_req(struct ieee80211com *ic, struct ieee80211_node *ni,
 	if (rs->rs_nrates > IEEE80211_RATE_SIZE)
 		frm = ieee80211_add_xrates(frm, rs);
 	if ((ic->ic_flags & IEEE80211_F_RSNON) &&
-	    (ni->ni_rsnprotos & IEEE80211_PROTO_RSN))
+		(ni->ni_rsnprotos & IEEE80211_PROTO_RSN)) {
+#ifdef AIRPORT
+		if (ic->ic_rsn_ie_override[1] > 0) {
+			memcpy(frm, ic->ic_rsn_ie_override, 2 + ic->ic_rsn_ie_override[1]);
+			frm += 2 + ic->ic_rsn_ie_override[1];
+		}
+		else
+#endif
 		frm = ieee80211_add_rsn(frm, ic, ni);
+	}
 	if (ni->ni_flags & IEEE80211_NODE_QOS)
 		frm = ieee80211_add_qos_capability(frm, ic);
 	if ((ic->ic_flags & IEEE80211_F_RSNON) &&
-	    (ni->ni_rsnprotos & IEEE80211_PROTO_WPA))
+		(ni->ni_rsnprotos & IEEE80211_PROTO_WPA)) {
+#ifdef AIRPORT
+		if (ic->ic_rsn_ie_override[1] > 0) {
+			memcpy(frm, ic->ic_rsn_ie_override, 2 + ic->ic_rsn_ie_override[1]);
+			frm += 2 + ic->ic_rsn_ie_override[1];
+		}
+		else
+#endif
 		frm = ieee80211_add_wpa(frm, ic, ni);
+	}
 	if (ic->ic_flags & IEEE80211_F_HTON) {
 		frm = ieee80211_add_htcaps(frm, ic);
 		frm = ieee80211_add_wme_info(frm, ic);

--- a/itl80211/openbsd/net80211/ieee80211_proto.c
+++ b/itl80211/openbsd/net80211/ieee80211_proto.c
@@ -1272,7 +1272,11 @@ justcleanup:
 				    (ni->ni_flags & IEEE80211_NODE_HT) ?
 					" HT enabled" : "");
 			}
+#ifdef AIRPORT
+			{
+#else
 			if (!(ic->ic_flags & IEEE80211_F_RSNON)) {
+#endif
 				/*
 				 * NB: When RSN is enabled, we defer setting
 				 * the link up until the port is valid.

--- a/itl80211/openbsd/net80211/ieee80211_var.h
+++ b/itl80211/openbsd/net80211/ieee80211_var.h
@@ -479,6 +479,9 @@ struct ieee80211com {
 	u_int8_t		ic_des_essid[IEEE80211_NWID_LEN];
 	struct ieee80211_channel *ic_des_chan;	/* desired channel */
 	u_int8_t		ic_des_bssid[IEEE80211_ADDR_LEN];
+#ifdef AIRPORT
+	u_int8_t		ic_rsn_ie_override[257];
+#endif
 	struct ieee80211_key	ic_nw_keys[IEEE80211_GROUP_NKID];
 	int			ic_def_txkey;	/* group data key index */
 #define ic_wep_txkey	ic_def_txkey

--- a/itlwm.xcodeproj/project.pbxproj
+++ b/itlwm.xcodeproj/project.pbxproj
@@ -68,6 +68,279 @@
 		024A08D223FCF395009FBA6C /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
 		024A08D423FCF3E6009FBA6C /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
 		024A08D623FCF4D7009FBA6C /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		35CBE659251CB89700435CBC /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6C2225027609000F77FF /* debug.h */; };
+		35CBE65A251CB89700435CBC /* IOSkywalkEthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD025021E66000F77FF /* IOSkywalkEthernetInterface.h */; };
+		35CBE65B251CB89700435CBC /* apple80211_ioctl.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC525021DEC000F77FF /* apple80211_ioctl.h */; };
+		35CBE65C251CB89700435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D42511C3CC00D0B92B /* IO80211VirtualInterface.h */; };
+		35CBE65D251CB89700435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D32511C3CC00D0B92B /* IO80211Interface.h */; };
+		35CBE65E251CB89700435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C7882507D6BD0015E6E6 /* IO80211Controller.h */; };
+		35CBE65F251CB89700435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD125021E66000F77FF /* IO80211P2PInterface.h */; };
+		35CBE660251CB89700435CBC /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCC25021E65000F77FF /* IO80211SkywalkInterface.h */; };
+		35CBE661251CB89700435CBC /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
+		35CBE662251CB89700435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78F250896E30015E6E6 /* IO80211VirtualInterface.h */; };
+		35CBE663251CB89700435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D62511C3CC00D0B92B /* IO80211P2PInterface.h */; };
+		35CBE664251CB89700435CBC /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
+		35CBE665251CB89700435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C7892507D6BD0015E6E6 /* IO80211Interface.h */; };
+		35CBE666251CB89700435CBC /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
+		35CBE667251CB89700435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D52511C3CC00D0B92B /* IO80211WorkLoop.h */; };
+		35CBE668251CB89700435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCE25021E66000F77FF /* IO80211Controller.h */; };
+		35CBE669251CB89700435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCF25021E66000F77FF /* IO80211Interface.h */; };
+		35CBE66A251CB89700435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCD25021E66000F77FF /* IO80211WorkLoop.h */; };
+		35CBE66B251CB89700435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78E250896E30015E6E6 /* IO80211P2PInterface.h */; };
+		35CBE66C251CB89700435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D72511C3CC00D0B92B /* IO80211Controller.h */; };
+		35CBE66D251CB89700435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD225021E66000F77FF /* IO80211VirtualInterface.h */; };
+		35CBE66E251CB89700435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78A2507D6BD0015E6E6 /* IO80211WorkLoop.h */; };
+		35CBE66F251CB89700435CBC /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
+		35CBE671251CB89700435CBC /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
+		35CBE672251CB89700435CBC /* _task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8F9EDE0240B7415009CB8E7 /* _task.cpp */; };
+		35CBE673251CB89700435CBC /* FwBinary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5076FA7F24CC71E40011B2BB /* FwBinary.cpp */; };
+		35CBE674251CB89700435CBC /* IOTaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8A33572244AED060039DA12 /* IOTaskQueue.cpp */; };
+		35CBE675251CB89700435CBC /* ieee80211_proto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC2F24080319007A9422 /* ieee80211_proto.c */; };
+		35CBE676251CB89700435CBC /* AirportItlwmInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8CA44A125091AF60036119A /* AirportItlwmInterface.cpp */; };
+		35CBE677251CB89700435CBC /* _string.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3024080319007A9422 /* _string.c */; };
+		35CBE678251CB89700435CBC /* ieee80211_ioctl.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3224080319007A9422 /* ieee80211_ioctl.c */; };
+		35CBE679251CB89700435CBC /* ieee80211.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3324080319007A9422 /* ieee80211.c */; };
+		35CBE67A251CB89700435CBC /* ieee80211_rssadapt.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3424080319007A9422 /* ieee80211_rssadapt.c */; };
+		35CBE67B251CB89700435CBC /* ieee80211_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3524080319007A9422 /* ieee80211_input.c */; };
+		35CBE67C251CB89700435CBC /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3724080319007A9422 /* timeout.c */; };
+		35CBE67D251CB89700435CBC /* ieee80211_mira.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3924080319007A9422 /* ieee80211_mira.c */; };
+		35CBE67E251CB89700435CBC /* ieee80211_crypto_bip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3B24080319007A9422 /* ieee80211_crypto_bip.c */; };
+		35CBE67F251CB89700435CBC /* ieee80211_crypto_tkip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3C24080319007A9422 /* ieee80211_crypto_tkip.c */; };
+		35CBE680251CB89700435CBC /* ieee80211_crypto_ccmp.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3D24080319007A9422 /* ieee80211_crypto_ccmp.c */; };
+		35CBE681251CB89700435CBC /* ieee80211_crypto_wep.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC462408031A007A9422 /* ieee80211_crypto_wep.c */; };
+		35CBE682251CB89700435CBC /* ieee80211_pae_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3E24080319007A9422 /* ieee80211_pae_input.c */; };
+		35CBE683251CB89700435CBC /* ieee80211_amrr.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4024080319007A9422 /* ieee80211_amrr.c */; };
+		35CBE684251CB89700435CBC /* ieee80211_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC472408031A007A9422 /* ieee80211_output.c */; };
+		35CBE685251CB89700435CBC /* ieee80211_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC482408031A007A9422 /* ieee80211_crypto.c */; };
+		35CBE686251CB89700435CBC /* CTimeout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC492408031A007A9422 /* CTimeout.cpp */; };
+		35CBE687251CB89700435CBC /* ieee80211_regdomain.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4B2408031A007A9422 /* ieee80211_regdomain.c */; };
+		35CBE688251CB89700435CBC /* ieee80211_node.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4C2408031A007A9422 /* ieee80211_node.c */; };
+		35CBE689251CB89700435CBC /* ieee80211_pae_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4D2408031A007A9422 /* ieee80211_pae_output.c */; };
+		35CBE68A251CB89700435CBC /* sha1-pbkdf2.c in Sources */ = {isa = PBXBuildFile; fileRef = F88D2B3B2414E64000BBE700 /* sha1-pbkdf2.c */; };
+		35CBE68B251CB89700435CBC /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07C923FCBC6C009FBA6C /* aes.c */; };
+		35CBE68C251CB89700435CBC /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CA23FCBC6C009FBA6C /* hmac.c */; };
+		35CBE68D251CB89700435CBC /* sha2.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CB23FCBC6C009FBA6C /* sha2.c */; };
+		35CBE68E251CB89700435CBC /* rijndael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CC23FCBC6C009FBA6C /* rijndael.c */; };
+		35CBE68F251CB89700435CBC /* ecb3_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CD23FCBC6C009FBA6C /* ecb3_enc.c */; };
+		35CBE690251CB89700435CBC /* set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CE23FCBC6C009FBA6C /* set_key.c */; };
+		35CBE691251CB89700435CBC /* cast.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CF23FCBC6C009FBA6C /* cast.c */; };
+		35CBE692251CB89700435CBC /* michael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D123FCBC6C009FBA6C /* michael.c */; };
+		35CBE693251CB89700435CBC /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D823FCBC6C009FBA6C /* sha1.c */; };
+		35CBE694251CB89700435CBC /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
+		35CBE695251CB89700435CBC /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
+		35CBE696251CB89700435CBC /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
+		35CBE697251CB89700435CBC /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
+		35CBE698251CB89700435CBC /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
+		35CBE699251CB89700435CBC /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
+		35CBE69A251CB89700435CBC /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07ED23FCBC6C009FBA6C /* poly1305.c */; };
+		35CBE69B251CB89700435CBC /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F023FCBC6C009FBA6C /* key_wrap.c */; };
+		35CBE69C251CB89700435CBC /* gmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F223FCBC6C009FBA6C /* gmac.c */; };
+		35CBE69D251CB89700435CBC /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F323FCBC6C009FBA6C /* rmd160.c */; };
+		35CBE69E251CB89700435CBC /* idgen.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F423FCBC6C009FBA6C /* idgen.c */; };
+		35CBE69F251CB89700435CBC /* compat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A07BA23FCBC6C009FBA6C /* compat.cpp */; };
+		35CBE6A0251CB89700435CBC /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F8FA0EED2501E8C100B1822E /* zutil.c */; };
+		35CBE6A1251CB89700435CBC /* ItlHalService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D364F624F93AFD0029340B /* ItlHalService.cpp */; };
+		35CBE6A2251CB89700435CBC /* ItlIwx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D6CD642442E8F200D2A454 /* ItlIwx.cpp */; };
+		35CBE6A3251CB89700435CBC /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BF23FCD4E2009FBA6C /* utils.cpp */; };
+		35CBE6A4251CB89700435CBC /* fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BD23FCD314009FBA6C /* fw.cpp */; };
+		35CBE6A5251CB89700435CBC /* io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C123FCD999009FBA6C /* io.cpp */; };
+		35CBE6A6251CB89700435CBC /* rx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C323FCDC14009FBA6C /* rx.cpp */; };
+		35CBE6A7251CB89700435CBC /* tx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C523FCDC3B009FBA6C /* tx.cpp */; };
+		35CBE6A8251CB89700435CBC /* hw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C723FCE2ED009FBA6C /* hw.cpp */; };
+		35CBE6A9251CB89700435CBC /* phy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C923FCE537009FBA6C /* phy.cpp */; };
+		35CBE6AA251CB89700435CBC /* mac80211.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CB23FCE5CA009FBA6C /* mac80211.cpp */; };
+		35CBE6AB251CB89700435CBC /* nvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CD23FCE67F009FBA6C /* nvm.cpp */; };
+		35CBE6AC251CB89700435CBC /* ctxt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CF23FCEE88009FBA6C /* ctxt.cpp */; };
+		35CBE6AD251CB89700435CBC /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
+		35CBE6AE251CB89700435CBC /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
+		35CBE6AF251CB89700435CBC /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		35CBE6B0251CB89700435CBC /* ItlIwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8AF3A2F24F9F35B008911C1 /* ItlIwm.cpp */; };
+		35CBE6B1251CB89700435CBC /* AirportSTAIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDC25022F8C000F77FF /* AirportSTAIOCTL.cpp */; };
+		35CBE6B2251CB89700435CBC /* AirportItlwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BBD25021C9C000F77FF /* AirportItlwm.cpp */; };
+		35CBE6B3251CB89700435CBC /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
+		35CBE6B4251CB89700435CBC /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
+		35CBE6C3251CB8BF00435CBC /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6C2225027609000F77FF /* debug.h */; };
+		35CBE6C4251CB8BF00435CBC /* IOSkywalkEthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD025021E66000F77FF /* IOSkywalkEthernetInterface.h */; };
+		35CBE6C5251CB8BF00435CBC /* apple80211_ioctl.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC525021DEC000F77FF /* apple80211_ioctl.h */; };
+		35CBE6C6251CB8BF00435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D42511C3CC00D0B92B /* IO80211VirtualInterface.h */; };
+		35CBE6C7251CB8BF00435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D32511C3CC00D0B92B /* IO80211Interface.h */; };
+		35CBE6C8251CB8BF00435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C7882507D6BD0015E6E6 /* IO80211Controller.h */; };
+		35CBE6C9251CB8BF00435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD125021E66000F77FF /* IO80211P2PInterface.h */; };
+		35CBE6CA251CB8BF00435CBC /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCC25021E65000F77FF /* IO80211SkywalkInterface.h */; };
+		35CBE6CB251CB8BF00435CBC /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
+		35CBE6CC251CB8BF00435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78F250896E30015E6E6 /* IO80211VirtualInterface.h */; };
+		35CBE6CD251CB8BF00435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D62511C3CC00D0B92B /* IO80211P2PInterface.h */; };
+		35CBE6CE251CB8BF00435CBC /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
+		35CBE6CF251CB8BF00435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C7892507D6BD0015E6E6 /* IO80211Interface.h */; };
+		35CBE6D0251CB8BF00435CBC /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
+		35CBE6D1251CB8BF00435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D52511C3CC00D0B92B /* IO80211WorkLoop.h */; };
+		35CBE6D2251CB8BF00435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCE25021E66000F77FF /* IO80211Controller.h */; };
+		35CBE6D3251CB8BF00435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCF25021E66000F77FF /* IO80211Interface.h */; };
+		35CBE6D4251CB8BF00435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCD25021E66000F77FF /* IO80211WorkLoop.h */; };
+		35CBE6D5251CB8BF00435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78E250896E30015E6E6 /* IO80211P2PInterface.h */; };
+		35CBE6D6251CB8BF00435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D72511C3CC00D0B92B /* IO80211Controller.h */; };
+		35CBE6D7251CB8BF00435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD225021E66000F77FF /* IO80211VirtualInterface.h */; };
+		35CBE6D8251CB8BF00435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78A2507D6BD0015E6E6 /* IO80211WorkLoop.h */; };
+		35CBE6D9251CB8BF00435CBC /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
+		35CBE6DB251CB8BF00435CBC /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
+		35CBE6DC251CB8BF00435CBC /* _task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8F9EDE0240B7415009CB8E7 /* _task.cpp */; };
+		35CBE6DD251CB8BF00435CBC /* FwBinary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5076FA7F24CC71E40011B2BB /* FwBinary.cpp */; };
+		35CBE6DE251CB8BF00435CBC /* IOTaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8A33572244AED060039DA12 /* IOTaskQueue.cpp */; };
+		35CBE6DF251CB8BF00435CBC /* ieee80211_proto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC2F24080319007A9422 /* ieee80211_proto.c */; };
+		35CBE6E0251CB8BF00435CBC /* AirportItlwmInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8CA44A125091AF60036119A /* AirportItlwmInterface.cpp */; };
+		35CBE6E1251CB8BF00435CBC /* _string.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3024080319007A9422 /* _string.c */; };
+		35CBE6E2251CB8BF00435CBC /* ieee80211_ioctl.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3224080319007A9422 /* ieee80211_ioctl.c */; };
+		35CBE6E3251CB8BF00435CBC /* ieee80211.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3324080319007A9422 /* ieee80211.c */; };
+		35CBE6E4251CB8BF00435CBC /* ieee80211_rssadapt.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3424080319007A9422 /* ieee80211_rssadapt.c */; };
+		35CBE6E5251CB8BF00435CBC /* ieee80211_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3524080319007A9422 /* ieee80211_input.c */; };
+		35CBE6E6251CB8BF00435CBC /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3724080319007A9422 /* timeout.c */; };
+		35CBE6E7251CB8BF00435CBC /* ieee80211_mira.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3924080319007A9422 /* ieee80211_mira.c */; };
+		35CBE6E8251CB8BF00435CBC /* ieee80211_crypto_bip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3B24080319007A9422 /* ieee80211_crypto_bip.c */; };
+		35CBE6E9251CB8BF00435CBC /* ieee80211_crypto_tkip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3C24080319007A9422 /* ieee80211_crypto_tkip.c */; };
+		35CBE6EA251CB8BF00435CBC /* ieee80211_crypto_ccmp.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3D24080319007A9422 /* ieee80211_crypto_ccmp.c */; };
+		35CBE6EB251CB8BF00435CBC /* ieee80211_crypto_wep.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC462408031A007A9422 /* ieee80211_crypto_wep.c */; };
+		35CBE6EC251CB8BF00435CBC /* ieee80211_pae_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3E24080319007A9422 /* ieee80211_pae_input.c */; };
+		35CBE6ED251CB8BF00435CBC /* ieee80211_amrr.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4024080319007A9422 /* ieee80211_amrr.c */; };
+		35CBE6EE251CB8BF00435CBC /* ieee80211_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC472408031A007A9422 /* ieee80211_output.c */; };
+		35CBE6EF251CB8BF00435CBC /* ieee80211_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC482408031A007A9422 /* ieee80211_crypto.c */; };
+		35CBE6F0251CB8BF00435CBC /* CTimeout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC492408031A007A9422 /* CTimeout.cpp */; };
+		35CBE6F1251CB8BF00435CBC /* ieee80211_regdomain.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4B2408031A007A9422 /* ieee80211_regdomain.c */; };
+		35CBE6F2251CB8BF00435CBC /* ieee80211_node.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4C2408031A007A9422 /* ieee80211_node.c */; };
+		35CBE6F3251CB8BF00435CBC /* ieee80211_pae_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4D2408031A007A9422 /* ieee80211_pae_output.c */; };
+		35CBE6F4251CB8BF00435CBC /* sha1-pbkdf2.c in Sources */ = {isa = PBXBuildFile; fileRef = F88D2B3B2414E64000BBE700 /* sha1-pbkdf2.c */; };
+		35CBE6F5251CB8BF00435CBC /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07C923FCBC6C009FBA6C /* aes.c */; };
+		35CBE6F6251CB8BF00435CBC /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CA23FCBC6C009FBA6C /* hmac.c */; };
+		35CBE6F7251CB8BF00435CBC /* sha2.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CB23FCBC6C009FBA6C /* sha2.c */; };
+		35CBE6F8251CB8BF00435CBC /* rijndael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CC23FCBC6C009FBA6C /* rijndael.c */; };
+		35CBE6F9251CB8BF00435CBC /* ecb3_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CD23FCBC6C009FBA6C /* ecb3_enc.c */; };
+		35CBE6FA251CB8BF00435CBC /* set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CE23FCBC6C009FBA6C /* set_key.c */; };
+		35CBE6FB251CB8BF00435CBC /* cast.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CF23FCBC6C009FBA6C /* cast.c */; };
+		35CBE6FC251CB8BF00435CBC /* michael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D123FCBC6C009FBA6C /* michael.c */; };
+		35CBE6FD251CB8BF00435CBC /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D823FCBC6C009FBA6C /* sha1.c */; };
+		35CBE6FE251CB8BF00435CBC /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
+		35CBE6FF251CB8BF00435CBC /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
+		35CBE700251CB8BF00435CBC /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
+		35CBE701251CB8BF00435CBC /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
+		35CBE702251CB8BF00435CBC /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
+		35CBE703251CB8BF00435CBC /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
+		35CBE704251CB8BF00435CBC /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07ED23FCBC6C009FBA6C /* poly1305.c */; };
+		35CBE705251CB8BF00435CBC /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F023FCBC6C009FBA6C /* key_wrap.c */; };
+		35CBE706251CB8BF00435CBC /* gmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F223FCBC6C009FBA6C /* gmac.c */; };
+		35CBE707251CB8BF00435CBC /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F323FCBC6C009FBA6C /* rmd160.c */; };
+		35CBE708251CB8BF00435CBC /* idgen.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F423FCBC6C009FBA6C /* idgen.c */; };
+		35CBE709251CB8BF00435CBC /* compat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A07BA23FCBC6C009FBA6C /* compat.cpp */; };
+		35CBE70A251CB8BF00435CBC /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F8FA0EED2501E8C100B1822E /* zutil.c */; };
+		35CBE70B251CB8BF00435CBC /* ItlHalService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D364F624F93AFD0029340B /* ItlHalService.cpp */; };
+		35CBE70C251CB8BF00435CBC /* ItlIwx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D6CD642442E8F200D2A454 /* ItlIwx.cpp */; };
+		35CBE70D251CB8BF00435CBC /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BF23FCD4E2009FBA6C /* utils.cpp */; };
+		35CBE70E251CB8BF00435CBC /* fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BD23FCD314009FBA6C /* fw.cpp */; };
+		35CBE70F251CB8BF00435CBC /* io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C123FCD999009FBA6C /* io.cpp */; };
+		35CBE710251CB8BF00435CBC /* rx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C323FCDC14009FBA6C /* rx.cpp */; };
+		35CBE711251CB8BF00435CBC /* tx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C523FCDC3B009FBA6C /* tx.cpp */; };
+		35CBE712251CB8BF00435CBC /* hw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C723FCE2ED009FBA6C /* hw.cpp */; };
+		35CBE713251CB8BF00435CBC /* phy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C923FCE537009FBA6C /* phy.cpp */; };
+		35CBE714251CB8BF00435CBC /* mac80211.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CB23FCE5CA009FBA6C /* mac80211.cpp */; };
+		35CBE715251CB8BF00435CBC /* nvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CD23FCE67F009FBA6C /* nvm.cpp */; };
+		35CBE716251CB8BF00435CBC /* ctxt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CF23FCEE88009FBA6C /* ctxt.cpp */; };
+		35CBE717251CB8BF00435CBC /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
+		35CBE718251CB8BF00435CBC /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
+		35CBE719251CB8BF00435CBC /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		35CBE71A251CB8BF00435CBC /* ItlIwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8AF3A2F24F9F35B008911C1 /* ItlIwm.cpp */; };
+		35CBE71B251CB8BF00435CBC /* AirportSTAIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDC25022F8C000F77FF /* AirportSTAIOCTL.cpp */; };
+		35CBE71C251CB8BF00435CBC /* AirportItlwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BBD25021C9C000F77FF /* AirportItlwm.cpp */; };
+		35CBE71D251CB8BF00435CBC /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
+		35CBE71E251CB8BF00435CBC /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
+		35CBE72E251CB8CA00435CBC /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6C2225027609000F77FF /* debug.h */; };
+		35CBE72F251CB8CA00435CBC /* IOSkywalkEthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD025021E66000F77FF /* IOSkywalkEthernetInterface.h */; };
+		35CBE730251CB8CA00435CBC /* apple80211_ioctl.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC525021DEC000F77FF /* apple80211_ioctl.h */; };
+		35CBE731251CB8CA00435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D42511C3CC00D0B92B /* IO80211VirtualInterface.h */; };
+		35CBE732251CB8CA00435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D32511C3CC00D0B92B /* IO80211Interface.h */; };
+		35CBE733251CB8CA00435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C7882507D6BD0015E6E6 /* IO80211Controller.h */; };
+		35CBE734251CB8CA00435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD125021E66000F77FF /* IO80211P2PInterface.h */; };
+		35CBE735251CB8CA00435CBC /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCC25021E65000F77FF /* IO80211SkywalkInterface.h */; };
+		35CBE736251CB8CA00435CBC /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
+		35CBE737251CB8CA00435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78F250896E30015E6E6 /* IO80211VirtualInterface.h */; };
+		35CBE738251CB8CA00435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D62511C3CC00D0B92B /* IO80211P2PInterface.h */; };
+		35CBE739251CB8CA00435CBC /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
+		35CBE73A251CB8CA00435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C7892507D6BD0015E6E6 /* IO80211Interface.h */; };
+		35CBE73B251CB8CA00435CBC /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
+		35CBE73C251CB8CA00435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D52511C3CC00D0B92B /* IO80211WorkLoop.h */; };
+		35CBE73D251CB8CA00435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCE25021E66000F77FF /* IO80211Controller.h */; };
+		35CBE73E251CB8CA00435CBC /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCF25021E66000F77FF /* IO80211Interface.h */; };
+		35CBE73F251CB8CA00435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BCD25021E66000F77FF /* IO80211WorkLoop.h */; };
+		35CBE740251CB8CA00435CBC /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78E250896E30015E6E6 /* IO80211P2PInterface.h */; };
+		35CBE741251CB8CA00435CBC /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D72511C3CC00D0B92B /* IO80211Controller.h */; };
+		35CBE742251CB8CA00435CBC /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD225021E66000F77FF /* IO80211VirtualInterface.h */; };
+		35CBE743251CB8CA00435CBC /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A0C78A2507D6BD0015E6E6 /* IO80211WorkLoop.h */; };
+		35CBE744251CB8CA00435CBC /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
+		35CBE746251CB8CA00435CBC /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
+		35CBE747251CB8CA00435CBC /* _task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8F9EDE0240B7415009CB8E7 /* _task.cpp */; };
+		35CBE748251CB8CA00435CBC /* FwBinary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5076FA7F24CC71E40011B2BB /* FwBinary.cpp */; };
+		35CBE749251CB8CA00435CBC /* IOTaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8A33572244AED060039DA12 /* IOTaskQueue.cpp */; };
+		35CBE74A251CB8CA00435CBC /* ieee80211_proto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC2F24080319007A9422 /* ieee80211_proto.c */; };
+		35CBE74B251CB8CA00435CBC /* AirportItlwmInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8CA44A125091AF60036119A /* AirportItlwmInterface.cpp */; };
+		35CBE74C251CB8CA00435CBC /* _string.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3024080319007A9422 /* _string.c */; };
+		35CBE74D251CB8CA00435CBC /* ieee80211_ioctl.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3224080319007A9422 /* ieee80211_ioctl.c */; };
+		35CBE74E251CB8CA00435CBC /* ieee80211.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3324080319007A9422 /* ieee80211.c */; };
+		35CBE74F251CB8CA00435CBC /* ieee80211_rssadapt.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3424080319007A9422 /* ieee80211_rssadapt.c */; };
+		35CBE750251CB8CA00435CBC /* ieee80211_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3524080319007A9422 /* ieee80211_input.c */; };
+		35CBE751251CB8CA00435CBC /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3724080319007A9422 /* timeout.c */; };
+		35CBE752251CB8CA00435CBC /* ieee80211_mira.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3924080319007A9422 /* ieee80211_mira.c */; };
+		35CBE753251CB8CA00435CBC /* ieee80211_crypto_bip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3B24080319007A9422 /* ieee80211_crypto_bip.c */; };
+		35CBE754251CB8CA00435CBC /* ieee80211_crypto_tkip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3C24080319007A9422 /* ieee80211_crypto_tkip.c */; };
+		35CBE755251CB8CA00435CBC /* ieee80211_crypto_ccmp.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3D24080319007A9422 /* ieee80211_crypto_ccmp.c */; };
+		35CBE756251CB8CA00435CBC /* ieee80211_crypto_wep.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC462408031A007A9422 /* ieee80211_crypto_wep.c */; };
+		35CBE757251CB8CA00435CBC /* ieee80211_pae_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3E24080319007A9422 /* ieee80211_pae_input.c */; };
+		35CBE758251CB8CA00435CBC /* ieee80211_amrr.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4024080319007A9422 /* ieee80211_amrr.c */; };
+		35CBE759251CB8CA00435CBC /* ieee80211_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC472408031A007A9422 /* ieee80211_output.c */; };
+		35CBE75A251CB8CA00435CBC /* ieee80211_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC482408031A007A9422 /* ieee80211_crypto.c */; };
+		35CBE75B251CB8CA00435CBC /* CTimeout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC492408031A007A9422 /* CTimeout.cpp */; };
+		35CBE75C251CB8CA00435CBC /* ieee80211_regdomain.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4B2408031A007A9422 /* ieee80211_regdomain.c */; };
+		35CBE75D251CB8CA00435CBC /* ieee80211_node.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4C2408031A007A9422 /* ieee80211_node.c */; };
+		35CBE75E251CB8CA00435CBC /* ieee80211_pae_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4D2408031A007A9422 /* ieee80211_pae_output.c */; };
+		35CBE75F251CB8CA00435CBC /* sha1-pbkdf2.c in Sources */ = {isa = PBXBuildFile; fileRef = F88D2B3B2414E64000BBE700 /* sha1-pbkdf2.c */; };
+		35CBE760251CB8CA00435CBC /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07C923FCBC6C009FBA6C /* aes.c */; };
+		35CBE761251CB8CA00435CBC /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CA23FCBC6C009FBA6C /* hmac.c */; };
+		35CBE762251CB8CA00435CBC /* sha2.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CB23FCBC6C009FBA6C /* sha2.c */; };
+		35CBE763251CB8CA00435CBC /* rijndael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CC23FCBC6C009FBA6C /* rijndael.c */; };
+		35CBE764251CB8CA00435CBC /* ecb3_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CD23FCBC6C009FBA6C /* ecb3_enc.c */; };
+		35CBE765251CB8CA00435CBC /* set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CE23FCBC6C009FBA6C /* set_key.c */; };
+		35CBE766251CB8CA00435CBC /* cast.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CF23FCBC6C009FBA6C /* cast.c */; };
+		35CBE767251CB8CA00435CBC /* michael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D123FCBC6C009FBA6C /* michael.c */; };
+		35CBE768251CB8CA00435CBC /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D823FCBC6C009FBA6C /* sha1.c */; };
+		35CBE769251CB8CA00435CBC /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
+		35CBE76A251CB8CA00435CBC /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
+		35CBE76B251CB8CA00435CBC /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
+		35CBE76C251CB8CA00435CBC /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
+		35CBE76D251CB8CA00435CBC /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
+		35CBE76E251CB8CA00435CBC /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
+		35CBE76F251CB8CA00435CBC /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07ED23FCBC6C009FBA6C /* poly1305.c */; };
+		35CBE770251CB8CA00435CBC /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F023FCBC6C009FBA6C /* key_wrap.c */; };
+		35CBE771251CB8CA00435CBC /* gmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F223FCBC6C009FBA6C /* gmac.c */; };
+		35CBE772251CB8CA00435CBC /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F323FCBC6C009FBA6C /* rmd160.c */; };
+		35CBE773251CB8CA00435CBC /* idgen.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F423FCBC6C009FBA6C /* idgen.c */; };
+		35CBE774251CB8CA00435CBC /* compat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A07BA23FCBC6C009FBA6C /* compat.cpp */; };
+		35CBE775251CB8CA00435CBC /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F8FA0EED2501E8C100B1822E /* zutil.c */; };
+		35CBE776251CB8CA00435CBC /* ItlHalService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D364F624F93AFD0029340B /* ItlHalService.cpp */; };
+		35CBE777251CB8CA00435CBC /* ItlIwx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D6CD642442E8F200D2A454 /* ItlIwx.cpp */; };
+		35CBE778251CB8CA00435CBC /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BF23FCD4E2009FBA6C /* utils.cpp */; };
+		35CBE779251CB8CA00435CBC /* fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BD23FCD314009FBA6C /* fw.cpp */; };
+		35CBE77A251CB8CA00435CBC /* io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C123FCD999009FBA6C /* io.cpp */; };
+		35CBE77B251CB8CA00435CBC /* rx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C323FCDC14009FBA6C /* rx.cpp */; };
+		35CBE77C251CB8CA00435CBC /* tx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C523FCDC3B009FBA6C /* tx.cpp */; };
+		35CBE77D251CB8CA00435CBC /* hw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C723FCE2ED009FBA6C /* hw.cpp */; };
+		35CBE77E251CB8CA00435CBC /* phy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C923FCE537009FBA6C /* phy.cpp */; };
+		35CBE77F251CB8CA00435CBC /* mac80211.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CB23FCE5CA009FBA6C /* mac80211.cpp */; };
+		35CBE780251CB8CA00435CBC /* nvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CD23FCE67F009FBA6C /* nvm.cpp */; };
+		35CBE781251CB8CA00435CBC /* ctxt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CF23FCEE88009FBA6C /* ctxt.cpp */; };
+		35CBE782251CB8CA00435CBC /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
+		35CBE783251CB8CA00435CBC /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
+		35CBE784251CB8CA00435CBC /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		35CBE785251CB8CA00435CBC /* ItlIwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8AF3A2F24F9F35B008911C1 /* ItlIwm.cpp */; };
+		35CBE786251CB8CA00435CBC /* AirportSTAIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDC25022F8C000F77FF /* AirportSTAIOCTL.cpp */; };
+		35CBE787251CB8CA00435CBC /* AirportItlwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BBD25021C9C000F77FF /* AirportItlwm.cpp */; };
+		35CBE788251CB8CA00435CBC /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
+		35CBE789251CB8CA00435CBC /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
 		F800B8D82511C3CC00D0B92B /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D32511C3CC00D0B92B /* IO80211Interface.h */; };
 		F800B8D92511C3CC00D0B92B /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D42511C3CC00D0B92B /* IO80211VirtualInterface.h */; };
 		F800B8DA2511C3CC00D0B92B /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F800B8D52511C3CC00D0B92B /* IO80211WorkLoop.h */; };
@@ -233,6 +506,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		35CBE657251CB89700435CBC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8EE4D1B24178BF0002FA666;
+			remoteInfo = fw_gen;
+		};
+		35CBE6C1251CB8BF00435CBC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8EE4D1B24178BF0002FA666;
+			remoteInfo = fw_gen;
+		};
+		35CBE72C251CB8CA00435CBC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8EE4D1B24178BF0002FA666;
+			remoteInfo = fw_gen;
+		};
 		F8585CC62501E05100485C5A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
@@ -316,6 +610,9 @@
 		024A08D123FCF395009FBA6C /* led.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = led.cpp; sourceTree = "<group>"; };
 		024A08D323FCF3E6009FBA6C /* power.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = power.cpp; sourceTree = "<group>"; };
 		024A08D523FCF4D7009FBA6C /* scan.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = scan.cpp; sourceTree = "<group>"; };
+		35CBE6BA251CB89700435CBC /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		35CBE724251CB8BF00435CBC /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		35CBE78F251CB8CA00435CBC /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		5076FA7F24CC71E40011B2BB /* FwBinary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FwBinary.cpp; sourceTree = "<group>"; };
 		F800B8D32511C3CC00D0B92B /* IO80211Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IO80211Interface.h; sourceTree = "<group>"; };
 		F800B8D42511C3CC00D0B92B /* IO80211VirtualInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IO80211VirtualInterface.h; sourceTree = "<group>"; };
@@ -461,6 +758,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		35CBE6B5251CB89700435CBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE71F251CB8BF00435CBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE78A251CB8CA00435CBC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F89B6BB625021C9C000F77FF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -487,6 +805,9 @@
 			children = (
 				024A07AC23FCBC3C009FBA6C /* itlwm.kext */,
 				F89B6BB925021C9C000F77FF /* AirportItlwm.kext */,
+				35CBE6BA251CB89700435CBC /* AirportItlwm.kext */,
+				35CBE724251CB8BF00435CBC /* AirportItlwm.kext */,
+				35CBE78F251CB8CA00435CBC /* AirportItlwm.kext */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -913,6 +1234,96 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		35CBE658251CB89700435CBC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE659251CB89700435CBC /* debug.h in Headers */,
+				35CBE65A251CB89700435CBC /* IOSkywalkEthernetInterface.h in Headers */,
+				35CBE65B251CB89700435CBC /* apple80211_ioctl.h in Headers */,
+				35CBE65C251CB89700435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE65D251CB89700435CBC /* IO80211Interface.h in Headers */,
+				35CBE65E251CB89700435CBC /* IO80211Controller.h in Headers */,
+				35CBE65F251CB89700435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE660251CB89700435CBC /* IO80211SkywalkInterface.h in Headers */,
+				35CBE661251CB89700435CBC /* apple80211_var.h in Headers */,
+				35CBE662251CB89700435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE663251CB89700435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE664251CB89700435CBC /* AirportItlwmInterface.hpp in Headers */,
+				35CBE665251CB89700435CBC /* IO80211Interface.h in Headers */,
+				35CBE666251CB89700435CBC /* AirportItlwm.hpp in Headers */,
+				35CBE667251CB89700435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE668251CB89700435CBC /* IO80211Controller.h in Headers */,
+				35CBE669251CB89700435CBC /* IO80211Interface.h in Headers */,
+				35CBE66A251CB89700435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE66B251CB89700435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE66C251CB89700435CBC /* IO80211Controller.h in Headers */,
+				35CBE66D251CB89700435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE66E251CB89700435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE66F251CB89700435CBC /* apple80211_wps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE6C2251CB8BF00435CBC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE6C3251CB8BF00435CBC /* debug.h in Headers */,
+				35CBE6C4251CB8BF00435CBC /* IOSkywalkEthernetInterface.h in Headers */,
+				35CBE6C5251CB8BF00435CBC /* apple80211_ioctl.h in Headers */,
+				35CBE6C6251CB8BF00435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE6C7251CB8BF00435CBC /* IO80211Interface.h in Headers */,
+				35CBE6C8251CB8BF00435CBC /* IO80211Controller.h in Headers */,
+				35CBE6C9251CB8BF00435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE6CA251CB8BF00435CBC /* IO80211SkywalkInterface.h in Headers */,
+				35CBE6CB251CB8BF00435CBC /* apple80211_var.h in Headers */,
+				35CBE6CC251CB8BF00435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE6CD251CB8BF00435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE6CE251CB8BF00435CBC /* AirportItlwmInterface.hpp in Headers */,
+				35CBE6CF251CB8BF00435CBC /* IO80211Interface.h in Headers */,
+				35CBE6D0251CB8BF00435CBC /* AirportItlwm.hpp in Headers */,
+				35CBE6D1251CB8BF00435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE6D2251CB8BF00435CBC /* IO80211Controller.h in Headers */,
+				35CBE6D3251CB8BF00435CBC /* IO80211Interface.h in Headers */,
+				35CBE6D4251CB8BF00435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE6D5251CB8BF00435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE6D6251CB8BF00435CBC /* IO80211Controller.h in Headers */,
+				35CBE6D7251CB8BF00435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE6D8251CB8BF00435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE6D9251CB8BF00435CBC /* apple80211_wps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE72D251CB8CA00435CBC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE72E251CB8CA00435CBC /* debug.h in Headers */,
+				35CBE72F251CB8CA00435CBC /* IOSkywalkEthernetInterface.h in Headers */,
+				35CBE730251CB8CA00435CBC /* apple80211_ioctl.h in Headers */,
+				35CBE731251CB8CA00435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE732251CB8CA00435CBC /* IO80211Interface.h in Headers */,
+				35CBE733251CB8CA00435CBC /* IO80211Controller.h in Headers */,
+				35CBE734251CB8CA00435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE735251CB8CA00435CBC /* IO80211SkywalkInterface.h in Headers */,
+				35CBE736251CB8CA00435CBC /* apple80211_var.h in Headers */,
+				35CBE737251CB8CA00435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE738251CB8CA00435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE739251CB8CA00435CBC /* AirportItlwmInterface.hpp in Headers */,
+				35CBE73A251CB8CA00435CBC /* IO80211Interface.h in Headers */,
+				35CBE73B251CB8CA00435CBC /* AirportItlwm.hpp in Headers */,
+				35CBE73C251CB8CA00435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE73D251CB8CA00435CBC /* IO80211Controller.h in Headers */,
+				35CBE73E251CB8CA00435CBC /* IO80211Interface.h in Headers */,
+				35CBE73F251CB8CA00435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE740251CB8CA00435CBC /* IO80211P2PInterface.h in Headers */,
+				35CBE741251CB8CA00435CBC /* IO80211Controller.h in Headers */,
+				35CBE742251CB8CA00435CBC /* IO80211VirtualInterface.h in Headers */,
+				35CBE743251CB8CA00435CBC /* IO80211WorkLoop.h in Headers */,
+				35CBE744251CB8CA00435CBC /* apple80211_wps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F89B6BB425021C9C000F77FF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -982,9 +1393,66 @@
 			productReference = 024A07AC23FCBC3C009FBA6C /* itlwm.kext */;
 			productType = "com.apple.product-type.kernel-extension";
 		};
-		F89B6BB825021C9C000F77FF /* AirportItlwm */ = {
+		35CBE655251CB89700435CBC /* AirportItlwm-Big Sur */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F89B6BC025021C9C000F77FF /* Build configuration list for PBXNativeTarget "AirportItlwm" */;
+			buildConfigurationList = 35CBE6B7251CB89700435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-Big Sur" */;
+			buildPhases = (
+				35CBE658251CB89700435CBC /* Headers */,
+				35CBE670251CB89700435CBC /* Sources */,
+				35CBE6B5251CB89700435CBC /* Frameworks */,
+				35CBE6B6251CB89700435CBC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				35CBE656251CB89700435CBC /* PBXTargetDependency */,
+			);
+			name = "AirportItlwm-Big Sur";
+			productName = AirportItlwm;
+			productReference = 35CBE6BA251CB89700435CBC /* AirportItlwm.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		35CBE6BF251CB8BF00435CBC /* AirportItlwm-Mojave */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 35CBE721251CB8BF00435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-Mojave" */;
+			buildPhases = (
+				35CBE6C2251CB8BF00435CBC /* Headers */,
+				35CBE6DA251CB8BF00435CBC /* Sources */,
+				35CBE71F251CB8BF00435CBC /* Frameworks */,
+				35CBE720251CB8BF00435CBC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				35CBE6C0251CB8BF00435CBC /* PBXTargetDependency */,
+			);
+			name = "AirportItlwm-Mojave";
+			productName = AirportItlwm;
+			productReference = 35CBE724251CB8BF00435CBC /* AirportItlwm.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		35CBE72A251CB8CA00435CBC /* AirportItlwm-High Sierra */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 35CBE78C251CB8CA00435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-High Sierra" */;
+			buildPhases = (
+				35CBE72D251CB8CA00435CBC /* Headers */,
+				35CBE745251CB8CA00435CBC /* Sources */,
+				35CBE78A251CB8CA00435CBC /* Frameworks */,
+				35CBE78B251CB8CA00435CBC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				35CBE72B251CB8CA00435CBC /* PBXTargetDependency */,
+			);
+			name = "AirportItlwm-High Sierra";
+			productName = AirportItlwm;
+			productReference = 35CBE78F251CB8CA00435CBC /* AirportItlwm.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		F89B6BB825021C9C000F77FF /* AirportItlwm-Catalina */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F89B6BC025021C9C000F77FF /* Build configuration list for PBXNativeTarget "AirportItlwm-Catalina" */;
 			buildPhases = (
 				F89B6BB425021C9C000F77FF /* Headers */,
 				F89B6BB525021C9C000F77FF /* Sources */,
@@ -996,7 +1464,7 @@
 			dependencies = (
 				F89C035A250DE91300B41C85 /* PBXTargetDependency */,
 			);
-			name = AirportItlwm;
+			name = "AirportItlwm-Catalina";
 			productName = AirportItlwm;
 			productReference = F89B6BB925021C9C000F77FF /* AirportItlwm.kext */;
 			productType = "com.apple.product-type.kernel-extension";
@@ -1012,6 +1480,15 @@
 				TargetAttributes = {
 					024A07AB23FCBC3C009FBA6C = {
 						CreatedOnToolsVersion = 11.1;
+						ProvisioningStyle = Automatic;
+					};
+					35CBE655251CB89700435CBC = {
+						ProvisioningStyle = Automatic;
+					};
+					35CBE6BF251CB8BF00435CBC = {
+						ProvisioningStyle = Automatic;
+					};
+					35CBE72A251CB8CA00435CBC = {
 						ProvisioningStyle = Automatic;
 					};
 					F89B6BB825021C9C000F77FF = {
@@ -1039,13 +1516,37 @@
 			targets = (
 				F8EE4D1B24178BF0002FA666 /* fw_gen */,
 				024A07AB23FCBC3C009FBA6C /* itlwm */,
-				F89B6BB825021C9C000F77FF /* AirportItlwm */,
+				35CBE72A251CB8CA00435CBC /* AirportItlwm-High Sierra */,
+				35CBE6BF251CB8BF00435CBC /* AirportItlwm-Mojave */,
+				F89B6BB825021C9C000F77FF /* AirportItlwm-Catalina */,
+				35CBE655251CB89700435CBC /* AirportItlwm-Big Sur */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		024A07AA23FCBC3C009FBA6C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE6B6251CB89700435CBC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE720251CB8BF00435CBC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE78B251CB8CA00435CBC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1136,6 +1637,231 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		35CBE670251CB89700435CBC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE671251CB89700435CBC /* _mbuf.cpp in Sources */,
+				35CBE672251CB89700435CBC /* _task.cpp in Sources */,
+				35CBE673251CB89700435CBC /* FwBinary.cpp in Sources */,
+				35CBE674251CB89700435CBC /* IOTaskQueue.cpp in Sources */,
+				35CBE675251CB89700435CBC /* ieee80211_proto.c in Sources */,
+				35CBE676251CB89700435CBC /* AirportItlwmInterface.cpp in Sources */,
+				35CBE677251CB89700435CBC /* _string.c in Sources */,
+				35CBE678251CB89700435CBC /* ieee80211_ioctl.c in Sources */,
+				35CBE679251CB89700435CBC /* ieee80211.c in Sources */,
+				35CBE67A251CB89700435CBC /* ieee80211_rssadapt.c in Sources */,
+				35CBE67B251CB89700435CBC /* ieee80211_input.c in Sources */,
+				35CBE67C251CB89700435CBC /* timeout.c in Sources */,
+				35CBE67D251CB89700435CBC /* ieee80211_mira.c in Sources */,
+				35CBE67E251CB89700435CBC /* ieee80211_crypto_bip.c in Sources */,
+				35CBE67F251CB89700435CBC /* ieee80211_crypto_tkip.c in Sources */,
+				35CBE680251CB89700435CBC /* ieee80211_crypto_ccmp.c in Sources */,
+				35CBE681251CB89700435CBC /* ieee80211_crypto_wep.c in Sources */,
+				35CBE682251CB89700435CBC /* ieee80211_pae_input.c in Sources */,
+				35CBE683251CB89700435CBC /* ieee80211_amrr.c in Sources */,
+				35CBE684251CB89700435CBC /* ieee80211_output.c in Sources */,
+				35CBE685251CB89700435CBC /* ieee80211_crypto.c in Sources */,
+				35CBE686251CB89700435CBC /* CTimeout.cpp in Sources */,
+				35CBE687251CB89700435CBC /* ieee80211_regdomain.c in Sources */,
+				35CBE688251CB89700435CBC /* ieee80211_node.c in Sources */,
+				35CBE689251CB89700435CBC /* ieee80211_pae_output.c in Sources */,
+				35CBE68A251CB89700435CBC /* sha1-pbkdf2.c in Sources */,
+				35CBE68B251CB89700435CBC /* aes.c in Sources */,
+				35CBE68C251CB89700435CBC /* hmac.c in Sources */,
+				35CBE68D251CB89700435CBC /* sha2.c in Sources */,
+				35CBE68E251CB89700435CBC /* rijndael.c in Sources */,
+				35CBE68F251CB89700435CBC /* ecb3_enc.c in Sources */,
+				35CBE690251CB89700435CBC /* set_key.c in Sources */,
+				35CBE691251CB89700435CBC /* cast.c in Sources */,
+				35CBE692251CB89700435CBC /* michael.c in Sources */,
+				35CBE693251CB89700435CBC /* sha1.c in Sources */,
+				35CBE694251CB89700435CBC /* cmac.c in Sources */,
+				35CBE695251CB89700435CBC /* ecb_enc.c in Sources */,
+				35CBE696251CB89700435CBC /* chachapoly.c in Sources */,
+				35CBE697251CB89700435CBC /* md5.c in Sources */,
+				35CBE698251CB89700435CBC /* arc4.c in Sources */,
+				35CBE699251CB89700435CBC /* blf.c in Sources */,
+				35CBE69A251CB89700435CBC /* poly1305.c in Sources */,
+				35CBE69B251CB89700435CBC /* key_wrap.c in Sources */,
+				35CBE69C251CB89700435CBC /* gmac.c in Sources */,
+				35CBE69D251CB89700435CBC /* rmd160.c in Sources */,
+				35CBE69E251CB89700435CBC /* idgen.c in Sources */,
+				35CBE69F251CB89700435CBC /* compat.cpp in Sources */,
+				35CBE6A0251CB89700435CBC /* zutil.c in Sources */,
+				35CBE6A1251CB89700435CBC /* ItlHalService.cpp in Sources */,
+				35CBE6A2251CB89700435CBC /* ItlIwx.cpp in Sources */,
+				35CBE6A3251CB89700435CBC /* utils.cpp in Sources */,
+				35CBE6A4251CB89700435CBC /* fw.cpp in Sources */,
+				35CBE6A5251CB89700435CBC /* io.cpp in Sources */,
+				35CBE6A6251CB89700435CBC /* rx.cpp in Sources */,
+				35CBE6A7251CB89700435CBC /* tx.cpp in Sources */,
+				35CBE6A8251CB89700435CBC /* hw.cpp in Sources */,
+				35CBE6A9251CB89700435CBC /* phy.cpp in Sources */,
+				35CBE6AA251CB89700435CBC /* mac80211.cpp in Sources */,
+				35CBE6AB251CB89700435CBC /* nvm.cpp in Sources */,
+				35CBE6AC251CB89700435CBC /* ctxt.cpp in Sources */,
+				35CBE6AD251CB89700435CBC /* led.cpp in Sources */,
+				35CBE6AE251CB89700435CBC /* power.cpp in Sources */,
+				35CBE6AF251CB89700435CBC /* scan.cpp in Sources */,
+				35CBE6B0251CB89700435CBC /* ItlIwm.cpp in Sources */,
+				35CBE6B1251CB89700435CBC /* AirportSTAIOCTL.cpp in Sources */,
+				35CBE6B2251CB89700435CBC /* AirportItlwm.cpp in Sources */,
+				35CBE6B3251CB89700435CBC /* AirportVirtualIOCTL.cpp in Sources */,
+				35CBE6B4251CB89700435CBC /* AirportAWDL.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE6DA251CB8BF00435CBC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE6DB251CB8BF00435CBC /* _mbuf.cpp in Sources */,
+				35CBE6DC251CB8BF00435CBC /* _task.cpp in Sources */,
+				35CBE6DD251CB8BF00435CBC /* FwBinary.cpp in Sources */,
+				35CBE6DE251CB8BF00435CBC /* IOTaskQueue.cpp in Sources */,
+				35CBE6DF251CB8BF00435CBC /* ieee80211_proto.c in Sources */,
+				35CBE6E0251CB8BF00435CBC /* AirportItlwmInterface.cpp in Sources */,
+				35CBE6E1251CB8BF00435CBC /* _string.c in Sources */,
+				35CBE6E2251CB8BF00435CBC /* ieee80211_ioctl.c in Sources */,
+				35CBE6E3251CB8BF00435CBC /* ieee80211.c in Sources */,
+				35CBE6E4251CB8BF00435CBC /* ieee80211_rssadapt.c in Sources */,
+				35CBE6E5251CB8BF00435CBC /* ieee80211_input.c in Sources */,
+				35CBE6E6251CB8BF00435CBC /* timeout.c in Sources */,
+				35CBE6E7251CB8BF00435CBC /* ieee80211_mira.c in Sources */,
+				35CBE6E8251CB8BF00435CBC /* ieee80211_crypto_bip.c in Sources */,
+				35CBE6E9251CB8BF00435CBC /* ieee80211_crypto_tkip.c in Sources */,
+				35CBE6EA251CB8BF00435CBC /* ieee80211_crypto_ccmp.c in Sources */,
+				35CBE6EB251CB8BF00435CBC /* ieee80211_crypto_wep.c in Sources */,
+				35CBE6EC251CB8BF00435CBC /* ieee80211_pae_input.c in Sources */,
+				35CBE6ED251CB8BF00435CBC /* ieee80211_amrr.c in Sources */,
+				35CBE6EE251CB8BF00435CBC /* ieee80211_output.c in Sources */,
+				35CBE6EF251CB8BF00435CBC /* ieee80211_crypto.c in Sources */,
+				35CBE6F0251CB8BF00435CBC /* CTimeout.cpp in Sources */,
+				35CBE6F1251CB8BF00435CBC /* ieee80211_regdomain.c in Sources */,
+				35CBE6F2251CB8BF00435CBC /* ieee80211_node.c in Sources */,
+				35CBE6F3251CB8BF00435CBC /* ieee80211_pae_output.c in Sources */,
+				35CBE6F4251CB8BF00435CBC /* sha1-pbkdf2.c in Sources */,
+				35CBE6F5251CB8BF00435CBC /* aes.c in Sources */,
+				35CBE6F6251CB8BF00435CBC /* hmac.c in Sources */,
+				35CBE6F7251CB8BF00435CBC /* sha2.c in Sources */,
+				35CBE6F8251CB8BF00435CBC /* rijndael.c in Sources */,
+				35CBE6F9251CB8BF00435CBC /* ecb3_enc.c in Sources */,
+				35CBE6FA251CB8BF00435CBC /* set_key.c in Sources */,
+				35CBE6FB251CB8BF00435CBC /* cast.c in Sources */,
+				35CBE6FC251CB8BF00435CBC /* michael.c in Sources */,
+				35CBE6FD251CB8BF00435CBC /* sha1.c in Sources */,
+				35CBE6FE251CB8BF00435CBC /* cmac.c in Sources */,
+				35CBE6FF251CB8BF00435CBC /* ecb_enc.c in Sources */,
+				35CBE700251CB8BF00435CBC /* chachapoly.c in Sources */,
+				35CBE701251CB8BF00435CBC /* md5.c in Sources */,
+				35CBE702251CB8BF00435CBC /* arc4.c in Sources */,
+				35CBE703251CB8BF00435CBC /* blf.c in Sources */,
+				35CBE704251CB8BF00435CBC /* poly1305.c in Sources */,
+				35CBE705251CB8BF00435CBC /* key_wrap.c in Sources */,
+				35CBE706251CB8BF00435CBC /* gmac.c in Sources */,
+				35CBE707251CB8BF00435CBC /* rmd160.c in Sources */,
+				35CBE708251CB8BF00435CBC /* idgen.c in Sources */,
+				35CBE709251CB8BF00435CBC /* compat.cpp in Sources */,
+				35CBE70A251CB8BF00435CBC /* zutil.c in Sources */,
+				35CBE70B251CB8BF00435CBC /* ItlHalService.cpp in Sources */,
+				35CBE70C251CB8BF00435CBC /* ItlIwx.cpp in Sources */,
+				35CBE70D251CB8BF00435CBC /* utils.cpp in Sources */,
+				35CBE70E251CB8BF00435CBC /* fw.cpp in Sources */,
+				35CBE70F251CB8BF00435CBC /* io.cpp in Sources */,
+				35CBE710251CB8BF00435CBC /* rx.cpp in Sources */,
+				35CBE711251CB8BF00435CBC /* tx.cpp in Sources */,
+				35CBE712251CB8BF00435CBC /* hw.cpp in Sources */,
+				35CBE713251CB8BF00435CBC /* phy.cpp in Sources */,
+				35CBE714251CB8BF00435CBC /* mac80211.cpp in Sources */,
+				35CBE715251CB8BF00435CBC /* nvm.cpp in Sources */,
+				35CBE716251CB8BF00435CBC /* ctxt.cpp in Sources */,
+				35CBE717251CB8BF00435CBC /* led.cpp in Sources */,
+				35CBE718251CB8BF00435CBC /* power.cpp in Sources */,
+				35CBE719251CB8BF00435CBC /* scan.cpp in Sources */,
+				35CBE71A251CB8BF00435CBC /* ItlIwm.cpp in Sources */,
+				35CBE71B251CB8BF00435CBC /* AirportSTAIOCTL.cpp in Sources */,
+				35CBE71C251CB8BF00435CBC /* AirportItlwm.cpp in Sources */,
+				35CBE71D251CB8BF00435CBC /* AirportVirtualIOCTL.cpp in Sources */,
+				35CBE71E251CB8BF00435CBC /* AirportAWDL.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35CBE745251CB8CA00435CBC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE746251CB8CA00435CBC /* _mbuf.cpp in Sources */,
+				35CBE747251CB8CA00435CBC /* _task.cpp in Sources */,
+				35CBE748251CB8CA00435CBC /* FwBinary.cpp in Sources */,
+				35CBE749251CB8CA00435CBC /* IOTaskQueue.cpp in Sources */,
+				35CBE74A251CB8CA00435CBC /* ieee80211_proto.c in Sources */,
+				35CBE74B251CB8CA00435CBC /* AirportItlwmInterface.cpp in Sources */,
+				35CBE74C251CB8CA00435CBC /* _string.c in Sources */,
+				35CBE74D251CB8CA00435CBC /* ieee80211_ioctl.c in Sources */,
+				35CBE74E251CB8CA00435CBC /* ieee80211.c in Sources */,
+				35CBE74F251CB8CA00435CBC /* ieee80211_rssadapt.c in Sources */,
+				35CBE750251CB8CA00435CBC /* ieee80211_input.c in Sources */,
+				35CBE751251CB8CA00435CBC /* timeout.c in Sources */,
+				35CBE752251CB8CA00435CBC /* ieee80211_mira.c in Sources */,
+				35CBE753251CB8CA00435CBC /* ieee80211_crypto_bip.c in Sources */,
+				35CBE754251CB8CA00435CBC /* ieee80211_crypto_tkip.c in Sources */,
+				35CBE755251CB8CA00435CBC /* ieee80211_crypto_ccmp.c in Sources */,
+				35CBE756251CB8CA00435CBC /* ieee80211_crypto_wep.c in Sources */,
+				35CBE757251CB8CA00435CBC /* ieee80211_pae_input.c in Sources */,
+				35CBE758251CB8CA00435CBC /* ieee80211_amrr.c in Sources */,
+				35CBE759251CB8CA00435CBC /* ieee80211_output.c in Sources */,
+				35CBE75A251CB8CA00435CBC /* ieee80211_crypto.c in Sources */,
+				35CBE75B251CB8CA00435CBC /* CTimeout.cpp in Sources */,
+				35CBE75C251CB8CA00435CBC /* ieee80211_regdomain.c in Sources */,
+				35CBE75D251CB8CA00435CBC /* ieee80211_node.c in Sources */,
+				35CBE75E251CB8CA00435CBC /* ieee80211_pae_output.c in Sources */,
+				35CBE75F251CB8CA00435CBC /* sha1-pbkdf2.c in Sources */,
+				35CBE760251CB8CA00435CBC /* aes.c in Sources */,
+				35CBE761251CB8CA00435CBC /* hmac.c in Sources */,
+				35CBE762251CB8CA00435CBC /* sha2.c in Sources */,
+				35CBE763251CB8CA00435CBC /* rijndael.c in Sources */,
+				35CBE764251CB8CA00435CBC /* ecb3_enc.c in Sources */,
+				35CBE765251CB8CA00435CBC /* set_key.c in Sources */,
+				35CBE766251CB8CA00435CBC /* cast.c in Sources */,
+				35CBE767251CB8CA00435CBC /* michael.c in Sources */,
+				35CBE768251CB8CA00435CBC /* sha1.c in Sources */,
+				35CBE769251CB8CA00435CBC /* cmac.c in Sources */,
+				35CBE76A251CB8CA00435CBC /* ecb_enc.c in Sources */,
+				35CBE76B251CB8CA00435CBC /* chachapoly.c in Sources */,
+				35CBE76C251CB8CA00435CBC /* md5.c in Sources */,
+				35CBE76D251CB8CA00435CBC /* arc4.c in Sources */,
+				35CBE76E251CB8CA00435CBC /* blf.c in Sources */,
+				35CBE76F251CB8CA00435CBC /* poly1305.c in Sources */,
+				35CBE770251CB8CA00435CBC /* key_wrap.c in Sources */,
+				35CBE771251CB8CA00435CBC /* gmac.c in Sources */,
+				35CBE772251CB8CA00435CBC /* rmd160.c in Sources */,
+				35CBE773251CB8CA00435CBC /* idgen.c in Sources */,
+				35CBE774251CB8CA00435CBC /* compat.cpp in Sources */,
+				35CBE775251CB8CA00435CBC /* zutil.c in Sources */,
+				35CBE776251CB8CA00435CBC /* ItlHalService.cpp in Sources */,
+				35CBE777251CB8CA00435CBC /* ItlIwx.cpp in Sources */,
+				35CBE778251CB8CA00435CBC /* utils.cpp in Sources */,
+				35CBE779251CB8CA00435CBC /* fw.cpp in Sources */,
+				35CBE77A251CB8CA00435CBC /* io.cpp in Sources */,
+				35CBE77B251CB8CA00435CBC /* rx.cpp in Sources */,
+				35CBE77C251CB8CA00435CBC /* tx.cpp in Sources */,
+				35CBE77D251CB8CA00435CBC /* hw.cpp in Sources */,
+				35CBE77E251CB8CA00435CBC /* phy.cpp in Sources */,
+				35CBE77F251CB8CA00435CBC /* mac80211.cpp in Sources */,
+				35CBE780251CB8CA00435CBC /* nvm.cpp in Sources */,
+				35CBE781251CB8CA00435CBC /* ctxt.cpp in Sources */,
+				35CBE782251CB8CA00435CBC /* led.cpp in Sources */,
+				35CBE783251CB8CA00435CBC /* power.cpp in Sources */,
+				35CBE784251CB8CA00435CBC /* scan.cpp in Sources */,
+				35CBE785251CB8CA00435CBC /* ItlIwm.cpp in Sources */,
+				35CBE786251CB8CA00435CBC /* AirportSTAIOCTL.cpp in Sources */,
+				35CBE787251CB8CA00435CBC /* AirportItlwm.cpp in Sources */,
+				35CBE788251CB8CA00435CBC /* AirportVirtualIOCTL.cpp in Sources */,
+				35CBE789251CB8CA00435CBC /* AirportAWDL.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F89B6BB525021C9C000F77FF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1214,6 +1940,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		35CBE656251CB89700435CBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8EE4D1B24178BF0002FA666 /* fw_gen */;
+			targetProxy = 35CBE657251CB89700435CBC /* PBXContainerItemProxy */;
+		};
+		35CBE6C0251CB8BF00435CBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8EE4D1B24178BF0002FA666 /* fw_gen */;
+			targetProxy = 35CBE6C1251CB8BF00435CBC /* PBXContainerItemProxy */;
+		};
+		35CBE72B251CB8CA00435CBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8EE4D1B24178BF0002FA666 /* fw_gen */;
+			targetProxy = 35CBE72C251CB8CA00435CBC /* PBXContainerItemProxy */;
+		};
 		F8585CC72501E05100485C5A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F8EE4D1B24178BF0002FA666 /* fw_gen */;
@@ -1363,7 +2104,7 @@
 				MODULE_VERSION = "$(MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.12;
+				SDKROOT = macosx;
 				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
 				WRAPPER_EXTENSION = kext;
 			};
@@ -1394,7 +2135,217 @@
 				MODULE_VERSION = "$(MARKETING_VERSION)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.12;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		35CBE6B8251CB89700435CBC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/Big Sur";
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					BigSur,
+					disable_Catalina,
+					disable_Mojave,
+					disable_HighSierra,
+					AIRPORT,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 1.1.0;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		35CBE6B9251CB89700435CBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/Big Sur";
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"ITLWM_VERSION=\\\"${MARKETING_VERSION}\\\"",
+					BigSur,
+					AIRPORT,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 1.1.0;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		35CBE722251CB8BF00435CBC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/Mojave";
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					Mojave,
+					disable_BigSur,
+					disable_Catalina,
+					disable_HighSierra,
+					AIRPORT,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MARKETING_VERSION = 1.1.0;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		35CBE723251CB8BF00435CBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/Mojave";
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"ITLWM_VERSION=\\\"${MARKETING_VERSION}\\\"",
+					Mojave,
+					AIRPORT,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MARKETING_VERSION = 1.1.0;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		35CBE78D251CB8CA00435CBC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/High Sierra";
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					HighSierra,
+					disable_BigSur,
+					disable_Mojave,
+					disable_Catalina,
+					AIRPORT,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 1.1.0;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		35CBE78E251CB8CA00435CBC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/High Sierra";
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"ITLWM_VERSION=\\\"${MARKETING_VERSION}\\\"",
+					HighSierra,
+					AIRPORT,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 1.1.0;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
 				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
 				WRAPPER_EXTENSION = kext;
 			};
@@ -1406,6 +2357,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/Catalina";
 				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1429,8 +2381,8 @@
 				MODULE_NAME = com.zxystd.AirportItlwm;
 				MODULE_VERSION = 1.0.0d1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.12;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
 				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
 				WRAPPER_EXTENSION = kext;
 			};
@@ -1442,6 +2394,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)/Catalina";
 				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				GCC_INPUT_FILETYPE = sourcecode.cpp.cpp;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1461,8 +2414,8 @@
 				MODULE_NAME = com.zxystd.AirportItlwm;
 				MODULE_VERSION = 1.0.0d1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.12;
+				PRODUCT_NAME = AirportItlwm;
+				SDKROOT = macosx;
 				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
 				WRAPPER_EXTENSION = kext;
 			};
@@ -1514,7 +2467,34 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F89B6BC025021C9C000F77FF /* Build configuration list for PBXNativeTarget "AirportItlwm" */ = {
+		35CBE6B7251CB89700435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-Big Sur" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				35CBE6B8251CB89700435CBC /* Debug */,
+				35CBE6B9251CB89700435CBC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		35CBE721251CB8BF00435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-Mojave" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				35CBE722251CB8BF00435CBC /* Debug */,
+				35CBE723251CB8BF00435CBC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		35CBE78C251CB8CA00435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-High Sierra" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				35CBE78D251CB8CA00435CBC /* Debug */,
+				35CBE78E251CB8CA00435CBC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F89B6BC025021C9C000F77FF /* Build configuration list for PBXNativeTarget "AirportItlwm-Catalina" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F89B6BC125021C9C000F77FF /* Debug */,

--- a/itlwm.xcodeproj/project.pbxproj
+++ b/itlwm.xcodeproj/project.pbxproj
@@ -1415,6 +1415,7 @@
 					disable_BigSur,
 					disable_Mojave,
 					disable_HighSierra,
+					AIRPORT,
 				);
 				INFOPLIST_FILE = AirportItlwm/Info.plist;
 				LIBRARY_SEARCH_PATHS = (
@@ -1446,6 +1447,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"ITLWM_VERSION=\\\"${MARKETING_VERSION}\\\"",
 					Catalina,
+					AIRPORT,
 				);
 				INFOPLIST_FILE = AirportItlwm/Info.plist;
 				LIBRARY_SEARCH_PATHS = (

--- a/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm (all).xcscheme
+++ b/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm (all).xcscheme
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "35CBE72A251CB8CA00435CBC"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-High Sierra"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "35CBE6BF251CB8BF00435CBC"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-Mojave"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F89B6BB825021C9C000F77FF"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-Catalina"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "35CBE655251CB89700435CBC"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-Big Sur"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "35CBE72A251CB8CA00435CBC"
+            BuildableName = "AirportItlwm.kext"
+            BlueprintName = "AirportItlwm-High Sierra"
+            ReferencedContainer = "container:itlwm.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/itlwm/hal_iwm/ItlIwm.cpp
+++ b/itlwm/hal_iwm/ItlIwm.cpp
@@ -118,16 +118,22 @@ clearScanningFlags()
     com.sc_flags &= ~(IWM_FLAG_SCANNING | IWM_FLAG_BGSCAN);
 }
 
-char *ItlIwm::
+const char *ItlIwm::
 getFirmwareVersion()
 {
     return com.sc_fwver;
 }
 
+const char *ItlIwm::
+getFirmwareName()
+{
+    return com.sc_fwname;
+}
+
 int16_t ItlIwm::
 getBSSNoise()
 {
-    return com.sc_noise;;
+    return com.sc_noise;
 }
 
 bool ItlIwm::

--- a/itlwm/hal_iwm/ItlIwm.hpp
+++ b/itlwm/hal_iwm/ItlIwm.hpp
@@ -59,13 +59,15 @@ public:
     virtual ItlDriverController *getDriverController() override;
     
     //driver info
-    virtual char *getFirmwareVersion() override;
+    virtual const char *getFirmwareVersion() override;
     
     virtual int16_t getBSSNoise() override;
     
     virtual bool is5GBandSupport() override;
     
     virtual int getTxNSS() override;
+    
+    virtual const char *getFirmwareName() override;
     
     //driver controller
     virtual void clearScanningFlags() override;

--- a/itlwm/hal_iwm/fw.cpp
+++ b/itlwm/hal_iwm/fw.cpp
@@ -583,6 +583,7 @@ out:
         fw->fw_status = IWM_FW_STATUS_DONE;
     wakeupOn(&sc->sc_fw);
     
+    OSSafeReleaseNULL(fwData);
     return err;
 }
 

--- a/itlwm/hal_iwm/mac80211.cpp
+++ b/itlwm/hal_iwm/mac80211.cpp
@@ -2616,11 +2616,13 @@ _iwm_start_task(OSObject *target, void *arg0, void *arg1, void *arg2, void *arg3
             goto sendit;
         }
         
+#ifndef AIRPORT // maybe we need to set IEEE80211_F_TX_MGMT_ONLY
         if (ic->ic_state != IEEE80211_S_RUN ||
             (ic->ic_xflags & IEEE80211_F_TX_MGMT_ONLY)) {
             ifp->if_snd->lockFlush();
             break;
         }
+#endif
         
         m = ifp->if_snd->lockDequeue();
 //        XYLog("%s if_snd->lockDequeue\n", __FUNCTION__);

--- a/itlwm/hal_iwx/ItlIwx.cpp
+++ b/itlwm/hal_iwx/ItlIwx.cpp
@@ -223,16 +223,22 @@ clearScanningFlags()
     com.sc_flags &= ~(IWX_FLAG_SCANNING | IWX_FLAG_BGSCAN);
 }
 
-char *ItlIwx::
+const char *ItlIwx::
 getFirmwareVersion()
 {
     return com.sc_fwver;
 }
 
+const char *ItlIwx::
+getFirmwareName()
+{
+    return com.sc_fwname;
+}
+
 int16_t ItlIwx::
 getBSSNoise()
 {
-    return com.sc_noise;;
+    return com.sc_noise;
 }
 
 bool ItlIwx::

--- a/itlwm/hal_iwx/ItlIwx.hpp
+++ b/itlwm/hal_iwx/ItlIwx.hpp
@@ -162,13 +162,15 @@ public:
     virtual ItlDriverController *getDriverController() override;
     
     //driver info
-    virtual char *getFirmwareVersion() override;
+    virtual const char *getFirmwareVersion() override;
     
     virtual int16_t getBSSNoise() override;
     
     virtual bool is5GBandSupport() override;
     
     virtual int getTxNSS() override;
+    
+    virtual const char *getFirmwareName() override;
     
     //driver controller
     virtual void clearScanningFlags() override;


### PR DESCRIPTION
Use IO80211Family's RSN supplicant. It works, but I've not yet backported some things that are necessary before merging:

- [x] RSN IE override. It's necessary to connect to (at least my) WPA2 Enterprise network
- [x] `setDISASSOCIATE` IOCTL. It's necessary to disconnect from network manually or in case of authentication failure (now it remains connected and can't scan).
- [x] Message for completing RSN authentication (needed on Big Sur to inform macOS that the authentication succeeded, else it calls `setDISASSOCIATE`)
- [x] Message when changing state – maybe it's already implemented, need to look code and test