### PR TITLE
Support deauthentication codes

### DIFF
--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -511,8 +511,6 @@ void AirportItlwm::stop(IOService *provider)
     releaseAll();
 }
 
-UInt32 currentStatus;
-
 bool AirportItlwm::
 setLinkStatus(UInt32 status, const IONetworkMedium * activeMedium, UInt64 speed, OSData * data)
 {
@@ -523,10 +521,10 @@ setLinkStatus(UInt32 status, const IONetworkMedium * activeMedium, UInt64 speed,
     currentStatus = status;
     if (fNetIf) {
         if (status & kIONetworkLinkActive) {
-            fNetIf->setLinkState(kIO80211NetworkLinkUp, 4);
+            fNetIf->setLinkState(kIO80211NetworkLinkUp, 0);
             fNetIf->postMessage(APPLE80211_M_LINK_CHANGED);
         } else if (!(status & kIONetworkLinkNoNetworkChange)) {
-            fNetIf->setLinkState(kIO80211NetworkLinkDown, 8);
+            fNetIf->setLinkState(kIO80211NetworkLinkDown, fHalService->get80211Controller()->ic_deauth_reason);
             fNetIf->postMessage(APPLE80211_M_LINK_CHANGED);
         }
     }

--- a/AirportItlwm/AirportItlwm.hpp
+++ b/AirportItlwm/AirportItlwm.hpp
@@ -151,6 +151,7 @@ public:
     FUNC_IOCTL_GET(HARDWARE_VERSION, apple80211_version_data)
     FUNC_IOCTL(RSN_IE, apple80211_rsn_ie_data)
     FUNC_IOCTL_GET(AP_IE_LIST, apple80211_ap_ie_data)
+    FUNC_IOCTL_GET(LINK_CHANGED_EVENT_DATA, apple80211_link_changed_event_data)
     FUNC_IOCTL_GET(ASSOCIATION_STATUS, apple80211_assoc_status_data)
     FUNC_IOCTL_GET(COUNTRY_CODE, apple80211_country_code_data)
     FUNC_IOCTL_GET(RADIO_INFO, apple80211_radio_info_data)
@@ -214,6 +215,9 @@ public:
     
     u_int32_t current_authtype_lower;
     u_int32_t current_authtype_upper;
+    UInt64 currentSpeed;
+    UInt32 currentStatus;
+    bool disassocIsVoluntary;
     
     IO80211P2PInterface *fP2PDISCInterface;
     IO80211P2PInterface *fP2PGOInterface;

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -402,29 +402,44 @@ IOReturn AirportItlwm::
 getCARD_CAPABILITIES(OSObject *object,
                                      struct apple80211_capability_data *cd)
 {
+    uint32_t caps = fHalService->get80211Controller()->ic_caps;
+    if (caps & IEEE80211_C_WEP)
+        cd->capabilities[0] |= 1 << APPLE80211_CAP_WEP;
+    if (caps & IEEE80211_C_RSN)
+        cd->capabilities[0] |= 1 << APPLE80211_CAP_TKIP | 1 << APPLE80211_CAP_AES_CCM;
+    // Disable not implemented capabilities
+    // if (caps & IEEE80211_C_PMGT)
+    //     cd->capabilities[0] |= 1 << APPLE80211_CAP_PMGT;
+    // if (caps & IEEE80211_C_IBSS)
+    //     cd->capabilities[0] |= 1 << APPLE80211_CAP_IBSS;
+    // if (caps & IEEE80211_C_HOSTAP)
+    //     cd->capabilities[0] |= 1 << APPLE80211_CAP_HOSTAP;
+    // AES not enabled, like on Apple cards
+    
+    if (caps & IEEE80211_C_SHSLOT)
+        cd->capabilities[1] |= 1 << (APPLE80211_CAP_SHSLOT - 8);
+    if (caps & IEEE80211_C_SHPREAMBLE)
+        cd->capabilities[1] |= 1 << (APPLE80211_CAP_SHPREAMBLE - 8);
+    if (caps & IEEE80211_C_RSN)
+        cd->capabilities[1] |= 1 << (APPLE80211_CAP_WPA1 - 8) | 1 << (APPLE80211_CAP_WPA2 - 8) | 1 << (APPLE80211_CAP_TKIPMIC - 8);
+    // Disable not implemented capabilities
+    // if (caps & IEEE80211_C_TXPMGT)
+    //     cd->capabilities[1] |= 1 << (APPLE80211_CAP_TXPMGT - 8);
+    // if (caps & IEEE80211_C_MONITOR)
+    //     cd->capabilities[1] |= 1 << (APPLE80211_CAP_MONITOR - 8);
+    // WPA not enabled, like on Apple cards
+
     cd->version = APPLE80211_VERSION;
-    cd->capabilities[0] = 0xEB;
-    cd->capabilities[1] = 0x7E;
-    cd->capabilities[2] = 0xFF;
-    cd->capabilities[5] |= 8;
-    cd->capabilities[3] |= 2;
-    cd->capabilities[4] |= 1;
-    cd->capabilities[6] |= 8;
-    cd->capabilities[8] |= 8;//dfs white list
-    cd->capabilities[3] |= 0x21;
-    cd->capabilities[4] |= 0x80;
-    cd->capabilities[5] |= 4;
-    cd->capabilities[2] |= 0xC0;
-    cd->capabilities[6] |= 0x84;
-    cd->capabilities[3] |= 8;
-    cd->capabilities[4] |= 0xAC;
-    cd->capabilities[6] |= 1;
-    cd->capabilities[7] |= 4;
-    cd->capabilities[5] |= 0x80;//isCntryDefaultSupported
-    cd->capabilities[7] |= 0x80;
-    cd->capabilities[8] |= 0x40;
-    cd->capabilities[9] |= 8;
-    cd->capabilities[9] |= 0x28;
+    cd->capabilities[2] = 0xFF; // BURST, WME, SHORT_GI_40MHZ, SHORT_GI_20MHZ, WOW, TSN, ?, ?
+    cd->capabilities[3] = 0x2B;
+    cd->capabilities[4] = 0xAD;
+    cd->capabilities[5] = 0x80;//isCntryDefaultSupported
+    cd->capabilities[5] |= 0x0C;
+    cd->capabilities[6] = 0x8D;
+    cd->capabilities[7] = 0x84; // This byte contains Apple Watch unlock
+    //cd->capabilities[8] = 0x40;
+    //cd->capabilities[8] |= 8;//dfs white list
+    //cd->capabilities[9] = 0x28;
     return kIOReturnSuccess;
 }
 

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -161,9 +161,10 @@ SInt32 AirportItlwm::apple80211Request(unsigned int request_type,
             IOCTL_GET(request_type, NSS, apple80211_nss_data);
             break;
         default:
+        unhandled:
             if (!ml_at_interrupt_context()) {
-                XYLog("%s Unhandled IOCTL %s (%d)\n", __FUNCTION__, IOCTL_NAMES[request_number],
-                      request_number);
+                XYLog("%s Unhandled IOCTL %s (%d) %s\n", __FUNCTION__, IOCTL_NAMES[request_number],
+                      request_number, request_type == SIOCGA80211 ? "get" : (request_type == SIOCSA80211 ? "set" : "other"));
             }
             break;
     }

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -932,7 +932,7 @@ getSCAN_RESULT(OSObject *object, struct apple80211_scan_result **sr)
     result->asr_channel.version = APPLE80211_VERSION;
     result->asr_channel.channel = ieee80211_chan2ieee(ic, fNextNodeToSend->ni_chan);
     result->asr_channel.flags = ieeeChanFlag2apple(fNextNodeToSend->ni_chan->ic_flags);
-    result->asr_noise = 0;
+    result->asr_noise = fHalService->getDriverInfo()->getBSSNoise();
     result->asr_rssi = -(0 - IWM_MIN_DBM - fNextNodeToSend->ni_rssi);
     memcpy(result->asr_bssid, fNextNodeToSend->ni_bssid, IEEE80211_ADDR_LEN);
     result->asr_ssid_len = fNextNodeToSend->ni_esslen;

--- a/AirportItlwm/AirportVirtualIOCTL.cpp
+++ b/AirportItlwm/AirportVirtualIOCTL.cpp
@@ -77,7 +77,11 @@ apple80211VirtualRequest(UInt request_type, int request_number, IO80211VirtualIn
             IOCTL(request_type, AWDL_ELECTION_METRIC, apple80211_awdl_election_metric);
             break;
         default:
-            XYLog("%s Unhandled IOCTL %s (%d)\n", __FUNCTION__, IOCTL_NAMES[request_number], request_number);
+        unhandled:
+            if (!ml_at_interrupt_context()) {
+                XYLog("%s Unhandled IOCTL %s (%d) %s\n", __FUNCTION__, IOCTL_NAMES[request_number],
+                      request_number, request_type == SIOCGA80211 ? "get" : (request_type == SIOCSA80211 ? "set" : "other"));
+            }
             break;
     }
     

--- a/itl80211/openbsd/net80211/ieee80211_input.c
+++ b/itl80211/openbsd/net80211/ieee80211_input.c
@@ -139,6 +139,11 @@ void    ieee80211_recv_bar(struct ieee80211com *, mbuf_t,
 void    ieee80211_bar_tid(struct ieee80211com *, struct ieee80211_node *,
                           u_int8_t, u_int16_t);
 
+#ifdef AIRPORT
+void notify(IONetworkInterface *iface, unsigned int messageCode);
+#endif
+
+
 /*
  * Retrieve the length in bytes of an 802.11 header.
  */
@@ -2230,6 +2235,10 @@ ieee80211_recv_auth(struct ieee80211com *ic, mbuf_t m,
 #endif
         return;
     }
+#ifdef AIRPORT
+    ic->ic_deauth_reason = IEEE80211_REASON_UNSPECIFIED;
+    ic->ic_assoc_status = 0xffff;
+#endif
     ieee80211_auth_open(ic, wh, ni, rxi, seq, status);
 }
 
@@ -2611,6 +2620,14 @@ ieee80211_recv_assoc_resp(struct ieee80211com *ic, mbuf_t m,
     
     capinfo = LE_READ_2(frm); frm += 2;
     status =  LE_READ_2(frm); frm += 2;
+    
+#ifdef AIRPORT
+    ic->ic_assoc_status = status;
+    if (status == IEEE80211_STATUS_SUCCESS) {
+        notify(ic->ic_ac.ac_if.iface, 9 /* APPLE80211_M_ASSOC_DONE */);
+    }
+#endif
+    
     if (status != IEEE80211_STATUS_SUCCESS) {
         if (ifp->if_flags & IFF_DEBUG)
             XYLog("%s: %sassociation failed (status %d)"
@@ -2763,6 +2780,12 @@ ieee80211_recv_deauth(struct ieee80211com *ic, mbuf_t m,
     
     reason = LE_READ_2(frm);
     
+#ifdef AIRPORT
+    XYLog("Deauth received, reason %d\n", reason);
+    ic->ic_deauth_reason = reason;
+    notify(ic->ic_ac.ac_if.iface, 32 /* APPLE80211_M_DEAUTH_RECEIVED */);
+#endif
+    
     ic->ic_stats.is_rx_deauth++;
     switch (ic->ic_opmode) {
         case IEEE80211_M_STA: {
@@ -2820,6 +2843,8 @@ ieee80211_recv_disassoc(struct ieee80211com *ic, mbuf_t m,
     frm = (const u_int8_t *)&wh[1];
     
     reason = LE_READ_2(frm);
+    
+    XYLog("Disassoc received, reason %d\n", reason);
     
     ic->ic_stats.is_rx_disassoc++;
     switch (ic->ic_opmode) {

--- a/itl80211/openbsd/net80211/ieee80211_var.h
+++ b/itl80211/openbsd/net80211/ieee80211_var.h
@@ -481,6 +481,8 @@ struct ieee80211com {
 	u_int8_t		ic_des_bssid[IEEE80211_ADDR_LEN];
 #ifdef AIRPORT
 	u_int8_t		ic_rsn_ie_override[257];
+    u_int16_t       ic_deauth_reason;
+    u_int16_t       ic_assoc_status;
 #endif
 	struct ieee80211_key	ic_nw_keys[IEEE80211_GROUP_NKID];
 	int			ic_def_txkey;	/* group data key index */


### PR DESCRIPTION
Pass through deauthentication codes to getDEAUTH and setLinkStatus, so that airportd knows the deauthentication reason and whether it is voluntary (because of setDISASSOCIATE) or caused by AP.
Add noise information in scan results.
Log unhandled set requests when only get is implemented or vice versa.