### PR TITLE
Fix rssi indicator value calculation in iwn driver.

### DIFF
--- a/itlwm/hal_iwn/ItlIwn.cpp
+++ b/itlwm/hal_iwn/ItlIwn.cpp
@@ -525,6 +525,8 @@ iwn_attach(struct iwn_softc *sc, struct pci_attach_args *pa)
 
     /* IBSS channel undefined for now. */
     ic->ic_ibss_chan = &ic->ic_channels[0];
+    
+    ic->ic_max_rssi = IWN_MAX_DBM - IWN_MIN_DBM;
 
     ifp->controller = getController();
     ifp->if_snd = IOPacketQueue::withCapacity(getTxQueueSize());
@@ -2172,6 +2174,8 @@ iwn_rx_done(struct iwn_softc *sc, struct iwn_rx_desc *desc,
     }
 
     rssi = ops->get_rssi(stat);
+    rssi = (0 - IWN_MIN_DBM) + rssi;    /* normalize */
+    rssi = MIN(rssi, ic->ic_max_rssi);    /* clip to max. 100% */
 
     chan = stat->chan;
     if (chan > IEEE80211_CHAN_MAX)

--- a/itlwm/hal_iwn/if_iwnreg.h
+++ b/itlwm/hal_iwn/if_iwnreg.h
@@ -2104,3 +2104,6 @@ static const char * const iwn_fw_errmsg[] = {
 #define IWN_BARRIER_READ_WRITE(sc)                    \
     bus_space_barrier((sc)->sc_st, (sc)->sc_sh, 0, (sc)->sc_sz,    \
         BUS_SPACE_BARRIER_READ | BUS_SPACE_BARRIER_WRITE)
+
+#define IWN_MIN_DBM    -100
+#define IWN_MAX_DBM    -33    /* realistic guess */


### PR DESCRIPTION
This fixes the rssi indicator (wifi signal bar) value calculation in iwn driver.

The original rssi calculation between iwn and iwm/iwx is slight different. The change uses the same formula and result proper rssi reporting in iwn.