### PR TITLE
Fix mira probe timer not fired.

### DIFF
--- a/itl80211/openbsd/net80211/ieee80211_mira.c
+++ b/itl80211/openbsd/net80211/ieee80211_mira.c
@@ -1275,6 +1275,15 @@ ieee80211_mira_cancel_timeouts(struct ieee80211_mira_node *mn)
 {
     int t;
     
+    for (t = 0; t < nitems(mn->probe_to); t++)
+        timeout_del(&mn->probe_to[t]);
+}
+
+void
+ieee80211_mira_node_free(struct ieee80211_mira_node *mn)
+{
+    int t;
+    
     for (t = 0; t < nitems(mn->probe_to); t++) {
         timeout_del(&mn->probe_to[t]);
         timeout_free(&mn->probe_to[t]);

--- a/itl80211/openbsd/net80211/ieee80211_mira.h
+++ b/itl80211/openbsd/net80211/ieee80211_mira.h
@@ -120,6 +120,9 @@ void	ieee80211_mira_choose(struct ieee80211_mira_node *,
 /* Cancel timeouts scheduled by ieee80211_mira_choose(). */
 void	ieee80211_mira_cancel_timeouts(struct ieee80211_mira_node *);
 
+/* Release rate control state. */
+void    ieee80211_mira_node_free(struct ieee80211_mira_node *);
+
 /* Returns RTS threshold to be used for a frame about to be transmitted. */
 int	ieee80211_mira_get_rts_threshold(struct ieee80211_mira_node *,
     struct ieee80211com *, struct ieee80211_node *, size_t);

--- a/itlwm/hal_iwm/mac80211.cpp
+++ b/itlwm/hal_iwm/mac80211.cpp
@@ -2788,7 +2788,7 @@ iwm_newstate(struct ieee80211com *ic, enum ieee80211_state nstate, int arg)
              ieee80211_ba_del(ni);
          }
         timeout_del(&sc->sc_calib_to);
-        ieee80211_mira_cancel_timeouts(&in->in_mn);
+        ieee80211_mira_node_free(&in->in_mn);
         that->iwm_del_task(sc, systq, &sc->ba_task);
         that->iwm_del_task(sc, systq, &sc->htprot_task);
     }
@@ -3316,7 +3316,7 @@ iwm_stop(struct _ifnet *ifp)
     
     in->in_phyctxt = NULL;
     if (ic->ic_state == IEEE80211_S_RUN)
-        ieee80211_mira_cancel_timeouts(&in->in_mn); /* XXX refcount? */
+        ieee80211_mira_node_free(&in->in_mn); /* XXX refcount? */
     
     sc->sc_flags &= ~(IWM_FLAG_SCANNING | IWM_FLAG_BGSCAN);
     sc->sc_flags &= ~IWM_FLAG_MAC_ACTIVE;

--- a/itlwm/hal_iwn/ItlIwn.cpp
+++ b/itlwm/hal_iwn/ItlIwn.cpp
@@ -1800,7 +1800,7 @@ iwn_newstate(struct ieee80211com *ic, enum ieee80211_state nstate, int arg)
             ieee80211_stop_ampdu_tx(ic, ni, -1);
             ieee80211_ba_del(ni);
         }
-        ieee80211_mira_cancel_timeouts(&wn->mn);
+        ieee80211_mira_node_free(&wn->mn);
         timeout_del(&sc->calib_to);
         sc->calib.state = IWN_CALIB_STATE_INIT;
         if (sc->sc_flags & IWN_FLAG_BGSCAN)


### PR DESCRIPTION
The MiRA rate adaption algorithm rely on time-based trigger and event-based trigger to probe different transmission rates.

There is a bug in the code where time-based timers got deleted inside function `ieee80211_mira_cancel_timeouts`. When future time-based event occurred, the timer won't be fired. This blocks probing better rates effectively. The original intention is to reset the timer only.

The fix adds another function `ieee80211_mira_node_free` to release the timers when driver shutdown.