### PR TITLE
Fix mira_node statistics in driver

### DIFF
--- a/itlwm/hal_iwn/ItlIwn.cpp
+++ b/itlwm/hal_iwn/ItlIwn.cpp
@@ -2347,9 +2347,9 @@ iwn_ampdu_rate_control(struct iwn_softc *sc, struct ieee80211_node *ni,
                 (SEQ_LT(ba->ba_winend, s) ||
                 (ba->ba_bitmap & (1 << bit)) == 0)) {
                 have_ack++;
-                wn->mn.frames = txdata->ampdu_nframes;
-                wn->mn.agglen = txdata->ampdu_nframes;
-                wn->mn.ampdu_size = txdata->ampdu_size;
+                wn->mn.frames++;
+                wn->mn.agglen++;
+                wn->mn.ampdu_size = txdata->ampdu_size / txdata->ampdu_nframes;
                 if (txdata->retries > 1)
                     wn->mn.retries++;
                 if (!SEQ_LT(ba->ba_winend, s))
@@ -2362,7 +2362,6 @@ iwn_ampdu_rate_control(struct iwn_softc *sc, struct ieee80211_node *ni,
         }
 
         if (have_ack > 0) {
-            wn->mn.txfail = wn->mn.frames - have_ack;
             iwn_mira_choose(sc, ni);
         }
     }


### PR DESCRIPTION
The itlwm driver uses MiRA algorithm to control the tx rate (upload). There is a bit disconnect between what the MiRA rate adaption statistics wants and what the iwm/iwn driver passed. Note, the iwx driver uses firmware based RA and do not use MiRA.

In the mira formula, `txfail` mean the whole single frame or the whole AMPDU frame get lost. The driver deduce the number of `txfail` from the number of missing ACKs in BA. This looks wrong to me that a temporary sub-frame lost in the ACK would count as whole frame lost. Counting on the number of retries is sufficient to calculate in the mira formula.

Also in mira formula, it calculate `ampdu_size * agglen` to count the number of bytes transmitted. The `ampdu_size` should be the average of each sub-frame ampdu size, rather than the total ampdu size of all sub-frames.

In the AMPDU code for iwm, there was an early return on `iwm_rx_tx_cmd` when frame count more than 1. This seems unnecessary and would affect mira statistics collection.