### PR TITLE
[iwn] Do not add rxon ht flags on initialization.

### DIFF
--- a/itlwm/hal_iwn/ItlIwn.cpp
+++ b/itlwm/hal_iwn/ItlIwn.cpp
@@ -5245,7 +5245,6 @@ iwn_config(struct iwn_softc *sc)
             rxchain |= (IWN_RXCHAIN_DRIVER_FORCE | IWN_RXCHAIN_MIMO_FORCE);
     }
     sc->rxon.rxchain = htole16(rxchain);
-    sc->rxon.flags |= htole32(iwn_get_rxon_ht_flags(ic, ic->ic_bss));
     DPRINTF(("setting configuration\n"));
     DPRINTF(("%s: rxon chan %d flags %x cck %x ofdm %x rxchain %x\n",
         __func__, sc->rxon.chan, le32toh(sc->rxon.flags), sc->rxon.cck_mask,


### PR DESCRIPTION
The ic_bss may contain ht flags that is incompatible with the default ic_ibss_chan used during initialization. Fixing #605 