### PR TITLE
Add AirportItlwm support for macOS 10.12 10.11 10.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   BUILD_OUTPUT: 'build/Build/Products/Debug'
+  BUILD_LEGACY_OUTPUT: 'build-legacy/Build/Products/Debug'
 
 jobs:
 
@@ -45,10 +46,27 @@ jobs:
       run: |
         xcodebuild -scheme "AirportItlwm (all)" -configuration Debug -derivedDataPath build GIT_COMMIT=_${SHORT_SHA} | xcpretty && exit ${PIPESTATUS[0]}
 
-    - name: Pack Artifacts
+    - name: Build AirportItlwm-legacy
+      run: |
+        xcodebuild -scheme "AirportItlwm-legacy" -configuration Debug -derivedDataPath build-legacy GIT_COMMIT=_${SHORT_SHA} | xcpretty && exit ${PIPESTATUS[0]}
+
+    - name: Pack Artifacts itlwm
       run: |
         cd $BUILD_OUTPUT
           zip -r itlwm-v${ITLWM_VER}-DEBUG-alpha-${SHORT_SHA}.zip itlwm.kext
+        cd -
+
+    - name: Pack Artifacts AirportItlwm
+      run: |
+        cd $BUILD_OUTPUT
+          while read -r tgt ; do
+            zip -r AirportItlwm-${tgt// /_}-v${ITLWM_VER}-DEBUG-alpha-${SHORT_SHA}.zip "$tgt"
+          done < <(find . -mindepth 1 -maxdepth 1 -type d -not -path "*.kext" | cut -c 3-)
+        cd -
+
+    - name: Pack Artifacts AirportItlwm-legacy
+      run: |
+        cd $BUILD_LEGACY_OUTPUT
           while read -r tgt ; do
             zip -r AirportItlwm-${tgt// /_}-v${ITLWM_VER}-DEBUG-alpha-${SHORT_SHA}.zip "$tgt"
           done < <(find . -mindepth 1 -maxdepth 1 -type d -not -path "*.kext" | cut -c 3-)
@@ -78,3 +96,21 @@ jobs:
         artifacts: "${{ env.BUILD_OUTPUT }}/*.zip"
         tag: "v${{ env.ITLWM_VER }}-alpha"
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload to Artifacts itlwm
+      uses: actions/upload-artifact@v2
+      with:
+        name: itlwm
+        path: "${{ env.BUILD_OUTPUT }}/itlwm-*.zip"
+
+    - name: Upload to Artifacts AirportItlwm
+      uses: actions/upload-artifact@v2
+      with:
+        name: AirportItlwm
+        path: "${{ env.BUILD_OUTPUT }}/AirportItlwm-*.zip"
+
+    - name: Upload to Artifacts AirportItlwm-legacy
+      uses: actions/upload-artifact@v2
+      with:
+        name: AirportItlwm-legacy
+        path: "${{ env.BUILD_LEGACY_OUTPUT }}/AirportItlwm-*.zip"

--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -484,8 +484,12 @@ bool AirportItlwm::initPCIPowerManagment(IOPCIDevice *provider)
 
 bool AirportItlwm::createWorkLoop()
 {
-    _fWorkloop = IO80211WorkLoop::workLoop();
-    return _fWorkloop != 0;
+    _fWorkloop = nullptr;
+    if (super::createWorkLoop())
+    {
+        _fWorkloop = OSDynamicCast(IO80211WorkLoop, super::getWorkLoop());
+    }
+    return _fWorkloop != nullptr;
 }
 
 IOWorkLoop *AirportItlwm::getWorkLoop() const

--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -914,6 +914,7 @@ void AirportItlwm::setPowerStateOn()
     pmPolicyMaker->acknowledgeSetPowerState();
 }
 
+#if __IO80211_TARGET >= __MAC_10_11
 int AirportItlwm::
 outputRaw80211Packet(IO80211Interface *interface, mbuf_t m)
 {
@@ -921,6 +922,7 @@ outputRaw80211Packet(IO80211Interface *interface, mbuf_t m)
     freePacket(m);
     return kIOReturnOutputDropped;
 }
+#endif
 
 UInt32 AirportItlwm::
 hardwareOutputQueueDepth(IO80211Interface *interface)

--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -368,6 +368,7 @@ bool AirportItlwm::start(IOService *provider)
         super::stop(pciNub);
         return false;
     }
+    _fWorkloop = OSDynamicCast(IO80211WorkLoop, getWorkLoop());
     if (_fWorkloop == NULL) {
         XYLog("No _fWorkloop!!\n");
         super::stop(pciNub);
@@ -482,21 +483,6 @@ bool AirportItlwm::initPCIPowerManagment(IOPCIDevice *provider)
     return true;
 }
 
-bool AirportItlwm::createWorkLoop()
-{
-    _fWorkloop = nullptr;
-    if (super::createWorkLoop())
-    {
-        _fWorkloop = OSDynamicCast(IO80211WorkLoop, super::getWorkLoop());
-    }
-    return _fWorkloop != nullptr;
-}
-
-IOWorkLoop *AirportItlwm::getWorkLoop() const
-{
-    return _fWorkloop;
-}
-
 IOReturn AirportItlwm::selectMedium(const IONetworkMedium *medium)
 {
     setSelectedMedium(medium);
@@ -587,7 +573,7 @@ void AirportItlwm::releaseAll()
             fWatchdogWorkLoop->release();
             fWatchdogWorkLoop = NULL;
         }
-        _fWorkloop->release();
+//        _fWorkloop->release();
         _fWorkloop = NULL;
     }
     unregistPM();

--- a/AirportItlwm/AirportItlwm.hpp
+++ b/AirportItlwm/AirportItlwm.hpp
@@ -115,7 +115,9 @@ public:
     static void fakeScanDone(OSObject *owner, IOTimerEventSource *sender);
     //authentication
     virtual bool useAppleRSNSupplicant(IO80211Interface *interface) override;
+#if __IO80211_TARGET >= __MAC_10_11
     virtual int outputRaw80211Packet(IO80211Interface *interface, mbuf_t m) override;
+#endif
     //virtual interface
     virtual SInt32 enableVirtualInterface(IO80211VirtualInterface *interface) override;
     virtual SInt32 disableVirtualInterface(IO80211VirtualInterface *interface) override;

--- a/AirportItlwm/Info.plist
+++ b/AirportItlwm/Info.plist
@@ -41,19 +41,19 @@
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.apple.iokit.IO80211Family</key>
-		<string>1200.12.2b1</string>
+		<string>400.0</string>
 		<key>com.apple.iokit.IONetworkingFamily</key>
-		<string>3.2</string>
+		<string>2.0</string>
 		<key>com.apple.iokit.IOPCIFamily</key>
-		<string>2.9</string>
+		<string>2.6.1</string>
 		<key>com.apple.kpi.bsd</key>
-		<string>16.7</string>
+		<string>11.0.0</string>
 		<key>com.apple.kpi.iokit</key>
-		<string>16.7</string>
+		<string>11.0.0</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>16.7</string>
+		<string>11.0.0</string>
 		<key>com.apple.kpi.mach</key>
-		<string>16.7</string>
+		<string>11.0.0</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Network-Root</string>

--- a/include/Airport/IO80211Controller.h
+++ b/include/Airport/IO80211Controller.h
@@ -207,12 +207,14 @@ public:
 #if __IO80211_TARGET >= __MAC_10_15
     virtual void getLogPipes(CCPipe**, CCPipe**, CCPipe**) {};
 #endif
+#if __IO80211_TARGET >= __MAC_10_13
     virtual IOReturn enablePacketTimestamping(void) {
         return kIOReturnUnsupported;
     }
     virtual IOReturn disablePacketTimestamping(void) {
         return kIOReturnUnsupported;
     }
+#endif
     virtual UInt32 selfDiagnosticsReport(int,char const*,UInt);
     virtual UInt32 getDataQueueDepth(OSObject *);
 #if __IO80211_TARGET >= __MAC_11_0
@@ -280,8 +282,10 @@ public:
     IOReturn setChanNoiseFloorLTE(apple80211_stat_report *,int);
     IOReturn setChanNoiseFloor(apple80211_stat_report *,int);
     IOReturn setChanCCA(apple80211_stat_report *,int);
+#if __IO80211_TARGET >= __MAC_10_15
     IOReturn setChanExtendedCCA(apple80211_stat_report *,apple80211_cca_report *);
     bool setLTECoexstat(apple80211_stat_report *,apple80211_lteCoex_report *);
+#endif
     bool setBTCoexstat(apple80211_stat_report *,apple80211_btCoex_report *);
     bool setAMPDUstat(apple80211_stat_report *,apple80211_ampdu_stat_report *,apple80211_channel *);
     UInt32 getCountryCode(apple80211_country_code_data *);
@@ -303,7 +307,9 @@ public:
 #if __IO80211_TARGET >= __MAC_10_15
     void notifyHostapState(apple80211_hostap_state *);
 #endif
+#if __IO80211_TARGET >= __MAC_10_13
     bool isAwdlAssistedDiscoveryEnabled(void);
+#endif
     void joinDone(scanSource,joinStatus);
     void joinStarted(scanSource,joinStatus);
     void handleChannelSwitchAnnouncement(apple80211_channel_switch_announcement *);

--- a/include/Airport/IO80211Controller.h
+++ b/include/Airport/IO80211Controller.h
@@ -199,11 +199,13 @@ public:
     virtual bool requiresExplicitMBufRelease() {
         return false;
     }
+#if __IO80211_TARGET >= __MAC_10_12
     virtual bool flowIdSupported() {
         return false;
     }
     virtual IO80211FlowQueueLegacy* requestFlowQueue(FlowIdMetadata const*);
     virtual void releaseFlowQueue(IO80211FlowQueue *);
+#endif
 #if __IO80211_TARGET >= __MAC_10_15
     virtual void getLogPipes(CCPipe**, CCPipe**, CCPipe**) {};
 #endif
@@ -215,8 +217,10 @@ public:
         return kIOReturnUnsupported;
     }
 #endif
+#if __IO80211_TARGET >= __MAC_10_12
     virtual UInt32 selfDiagnosticsReport(int,char const*,UInt);
     virtual UInt32 getDataQueueDepth(OSObject *);
+#endif
 #if __IO80211_TARGET >= __MAC_11_0
     virtual bool isAssociatedToMovingNetwork(void) { return false; }
 #endif

--- a/include/Airport/IO80211Controller.h
+++ b/include/Airport/IO80211Controller.h
@@ -166,8 +166,10 @@ public:
     virtual void requestPacketTx(void*, UInt);
     virtual IOReturn getHardwareAddressForInterface(IO80211Interface *,IOEthernetAddress *);
     virtual void inputMonitorPacket(mbuf_t,UInt,void *,unsigned long);
+#if __IO80211_TARGET >= __MAC_10_11
     virtual int outputRaw80211Packet(IO80211Interface *,mbuf_t);
     virtual int outputActionFrame(IO80211Interface *,mbuf_t);
+#endif
     virtual int bpfOutputPacket(OSObject *,UInt,mbuf_t m);
     virtual SInt32 monitorModeSetEnabled(IO80211Interface*, bool, UInt);
     virtual IO80211Interface* getNetworkInterface(void);

--- a/include/Airport/IO80211Interface.h
+++ b/include/Airport/IO80211Interface.h
@@ -112,7 +112,9 @@ public:
     virtual void setEnabledBySystem(bool);
 
     virtual bool setLinkState(IO80211LinkState, unsigned int);
+#if __IO80211_TARGET >= __MAC_10_11
     virtual bool setLinkState(IO80211LinkState, int, unsigned int);
+#endif
     virtual UInt32 outputPacket(mbuf_t, void*);
 
     virtual bool setLinkQualityMetric(int);

--- a/include/Airport/IO80211Interface.h
+++ b/include/Airport/IO80211Interface.h
@@ -213,7 +213,9 @@ public:
     IOReturn reportDataTransferRates(void);
     IOReturn reportDataTransferRatesGated(void);
     IOReturn reportDataTransferRatesStatic(void *);
+#if __IO80211_TARGET >= __MAC_10_13
     IOReturn reportTransmitCompletionStatus(mbuf_t,int,UInt,UInt,UInt);
+#endif
     void reportTransmitStatus(mbuf_t,int,packet_info_tx *);
     void reportTxStatistics(apple80211_txstats *);
     void resetLeakyApStats(void);
@@ -230,11 +232,15 @@ public:
     void setDataPathState(bool);
     IOReturn setDataPointerAndLengthForMessageType(apple80211_postMessage_tlv_types,void **,unsigned long *);
     void setDebugFlags(unsigned long long,UInt);
+#if __IO80211_TARGET >= __MAC_10_13
     bool setFrameStats(apple80211_stat_report *,apple80211_frame_counters *);
+#endif
     bool setInterfaceCCA(apple80211_channel,int);
+#if __IO80211_TARGET >= __MAC_10_13
     bool setInterfaceChipCounters(apple80211_stat_report *,apple80211_chip_counters_tx *,apple80211_chip_error_counters_tx *,apple80211_chip_counters_rx *);
     bool setInterfaceExtendedCCA(apple80211_channel,apple80211_cca_report *);
     bool setInterfaceMIBdot11(apple80211_stat_report *,apple80211_ManagementInformationBasedot11_counters *);
+#endif
     IOReturn setLQM(unsigned long long);
     IOReturn setLQMGated(long long);
     IOReturn setLQMStatic(void *,void *);

--- a/include/Airport/IO80211P2PInterface.h
+++ b/include/Airport/IO80211P2PInterface.h
@@ -93,7 +93,9 @@ public:
 #if __IO80211_TARGET >= __MAC_10_15
     void notifyHostapState(apple80211_hostap_state *);
 #endif
+#if __IO80211_TARGET >= __MAC_10_13
     bool isAwdlAssistedDiscoveryEnabled(void);
+#endif
     void handleChannelSwitchAnnouncement(apple80211_channel_switch_announcement *);
     void awdlSetUnitNumber(char const*);
     void awdlInit(void);

--- a/include/Airport/IO80211P2PInterface.h
+++ b/include/Airport/IO80211P2PInterface.h
@@ -38,7 +38,9 @@ public:
                                            unsigned long   stateNumber,
                                            IOService *     whatDevice ) APPLE_KEXT_OVERRIDE;
     virtual bool init(IO80211Controller *,ether_addr *,uint,char const*) APPLE_KEXT_OVERRIDE;
+#if __IO80211_TARGET >= __MAC_10_12
     virtual bool createPeerManager(ether_addr *,IO80211PeerManager **) APPLE_KEXT_OVERRIDE;
+#endif
     virtual IOMediumType getMediumType() APPLE_KEXT_OVERRIDE;
     virtual void setLinkState(IO80211LinkState,uint) APPLE_KEXT_OVERRIDE;
     virtual bool dequeueOutputPacketsWithServiceClass(uint,IOMbufServiceClass,mbuf_t*,mbuf_t*,UInt *,unsigned long long *) APPLE_KEXT_OVERRIDE;
@@ -49,8 +51,10 @@ public:
     virtual IOReturn controllerWillChangePowerState(IO80211Controller *,unsigned long,UInt,IOService *) APPLE_KEXT_OVERRIDE;
     virtual IOReturn controllerDidChangePowerState(IO80211Controller *,unsigned long,UInt,IOService *) APPLE_KEXT_OVERRIDE;
     virtual bool handleDebugCmd(apple80211_debug_command *) APPLE_KEXT_OVERRIDE;
+#if __IO80211_TARGET >= __MAC_10_12
     virtual IOReturn postPeerPresence(ether_addr *,int,int,int,char *) APPLE_KEXT_OVERRIDE;
     virtual IOReturn postPeerAbsence(ether_addr *) APPLE_KEXT_OVERRIDE;
+#endif
 #if __IO80211_TARGET >= __MAC_10_15
     virtual IOReturn postPeerPresenceIPv6(ether_addr *,int,int,int,char *,unsigned char *) APPLE_KEXT_OVERRIDE;
 #endif
@@ -61,9 +65,11 @@ public:
     virtual void outputStart(uint) APPLE_KEXT_OVERRIDE;
     virtual UInt32 configureAQMOutput() APPLE_KEXT_OVERRIDE;
     virtual void setUnitNumber(char const*) APPLE_KEXT_OVERRIDE;
+#if __IO80211_TARGET >= __MAC_10_12
     virtual bool initIfnetEparams(ifnet_init_eparams *) APPLE_KEXT_OVERRIDE;
     virtual bool attachToBpf() APPLE_KEXT_OVERRIDE;
     virtual bool configureIfnet() APPLE_KEXT_OVERRIDE;
+#endif
     OSMetaClassDeclareReservedUnused( IO80211P2PInterface,  0);
     OSMetaClassDeclareReservedUnused( IO80211P2PInterface,  1);
     OSMetaClassDeclareReservedUnused( IO80211P2PInterface,  2);

--- a/include/Airport/IO80211VirtualInterface.h
+++ b/include/Airport/IO80211VirtualInterface.h
@@ -52,7 +52,9 @@ public:
                                            unsigned long   stateNumber,
                                            IOService *     whatDevice ) APPLE_KEXT_OVERRIDE;
     virtual bool init(IO80211Controller *,ether_addr *,UInt,char const*);
+#if __IO80211_TARGET >= __MAC_10_12
     virtual bool createPeerManager(ether_addr *,IO80211PeerManager **);
+#endif
     virtual IOMediumType getMediumType();
     virtual void setLinkState(IO80211LinkState,UInt);
     virtual bool dequeueOutputPacketsWithServiceClass(UInt,IOMbufServiceClass,mbuf_t*,mbuf_t*,UInt *,unsigned long long *);
@@ -63,8 +65,10 @@ public:
     virtual IOReturn controllerWillChangePowerState(IO80211Controller *,unsigned long,UInt,IOService *);
     virtual IOReturn controllerDidChangePowerState(IO80211Controller *,unsigned long,UInt,IOService *);
     virtual bool handleDebugCmd(apple80211_debug_command *);
+#if __IO80211_TARGET >= __MAC_10_12
     virtual IOReturn postPeerPresence(ether_addr *,int,int,int,char *);
     virtual IOReturn postPeerAbsence(ether_addr *);
+#endif
 #if __IO80211_TARGET >= __MAC_10_15
     virtual IOReturn postPeerPresenceIPv6(ether_addr *,int,int,int,char *,unsigned char *);
 #endif
@@ -75,9 +79,11 @@ public:
     virtual void outputStart(UInt);
     virtual UInt32 configureAQMOutput();
     virtual void setUnitNumber(char const*);
+#if __IO80211_TARGET >= __MAC_10_12
     virtual bool initIfnetEparams(ifnet_init_eparams *);
     virtual bool attachToBpf();
     virtual bool configureIfnet();
+#endif
     OSMetaClassDeclareReservedUnused( IO80211VirtualInterface,  0);
     OSMetaClassDeclareReservedUnused( IO80211VirtualInterface,  1);
     OSMetaClassDeclareReservedUnused( IO80211VirtualInterface,  2);

--- a/itlwm.xcodeproj/project.pbxproj
+++ b/itlwm.xcodeproj/project.pbxproj
@@ -167,6 +167,176 @@
 		1776949726578D930019558D /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
 		1776949826578D930019558D /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
 		1776949A26578D930019558D /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5088ECBC252884870068A63D /* libkmod.a */; };
+		17EA50B0267F1712005FA1FB /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6C2225027609000F77FF /* debug.h */; };
+		17EA50B1267F1712005FA1FB /* IOSkywalkEthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD025021E66000F77FF /* IOSkywalkEthernetInterface.h */; };
+		17EA50B2267F1712005FA1FB /* apple80211_ioctl.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC525021DEC000F77FF /* apple80211_ioctl.h */; };
+		17EA50B3267F1712005FA1FB /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA36252D834500520FD4 /* IO80211P2PInterface.h */; };
+		17EA50B4267F1712005FA1FB /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA39252D834500520FD4 /* IO80211WorkLoop.h */; };
+		17EA50B5267F1712005FA1FB /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
+		17EA50B6267F1712005FA1FB /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
+		17EA50B7267F1712005FA1FB /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA38252D834500520FD4 /* IO80211Interface.h */; };
+		17EA50B8267F1712005FA1FB /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA37252D834500520FD4 /* IO80211SkywalkInterface.h */; };
+		17EA50B9267F1712005FA1FB /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
+		17EA50BA267F1712005FA1FB /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA34252D834500520FD4 /* IO80211VirtualInterface.h */; };
+		17EA50BB267F1712005FA1FB /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA35252D834500520FD4 /* IO80211Controller.h */; };
+		17EA50BC267F1712005FA1FB /* ieee80211_ra.h in Headers */ = {isa = PBXBuildFile; fileRef = F8C594D225FD935B0007D19C /* ieee80211_ra.h */; };
+		17EA50BD267F1712005FA1FB /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
+		17EA50BF267F1712005FA1FB /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
+		17EA50C0267F1712005FA1FB /* ieee80211_ra.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C594D125FD935B0007D19C /* ieee80211_ra.c */; };
+		17EA50C1267F1712005FA1FB /* _task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8F9EDE0240B7415009CB8E7 /* _task.cpp */; };
+		17EA50C2267F1712005FA1FB /* FwBinary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5076FA7F24CC71E40011B2BB /* FwBinary.cpp */; };
+		17EA50C3267F1712005FA1FB /* IOTaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8A33572244AED060039DA12 /* IOTaskQueue.cpp */; };
+		17EA50C4267F1712005FA1FB /* ieee80211_proto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC2F24080319007A9422 /* ieee80211_proto.c */; };
+		17EA50C5267F1712005FA1FB /* AirportItlwmInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8CA44A125091AF60036119A /* AirportItlwmInterface.cpp */; };
+		17EA50C6267F1712005FA1FB /* _string.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3024080319007A9422 /* _string.c */; };
+		17EA50C7267F1712005FA1FB /* ieee80211_ioctl.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3224080319007A9422 /* ieee80211_ioctl.c */; };
+		17EA50C8267F1712005FA1FB /* ieee80211.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3324080319007A9422 /* ieee80211.c */; };
+		17EA50C9267F1712005FA1FB /* ieee80211_rssadapt.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3424080319007A9422 /* ieee80211_rssadapt.c */; };
+		17EA50CA267F1712005FA1FB /* ieee80211_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3524080319007A9422 /* ieee80211_input.c */; };
+		17EA50CB267F1712005FA1FB /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3724080319007A9422 /* timeout.c */; };
+		17EA50CC267F1712005FA1FB /* ieee80211_mira.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3924080319007A9422 /* ieee80211_mira.c */; };
+		17EA50CD267F1712005FA1FB /* ieee80211_crypto_bip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3B24080319007A9422 /* ieee80211_crypto_bip.c */; };
+		17EA50CE267F1712005FA1FB /* ieee80211_crypto_tkip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3C24080319007A9422 /* ieee80211_crypto_tkip.c */; };
+		17EA50CF267F1712005FA1FB /* ieee80211_crypto_ccmp.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3D24080319007A9422 /* ieee80211_crypto_ccmp.c */; };
+		17EA50D0267F1712005FA1FB /* ieee80211_crypto_wep.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC462408031A007A9422 /* ieee80211_crypto_wep.c */; };
+		17EA50D1267F1712005FA1FB /* ieee80211_pae_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3E24080319007A9422 /* ieee80211_pae_input.c */; };
+		17EA50D2267F1712005FA1FB /* ieee80211_amrr.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4024080319007A9422 /* ieee80211_amrr.c */; };
+		17EA50D3267F1712005FA1FB /* ieee80211_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC472408031A007A9422 /* ieee80211_output.c */; };
+		17EA50D4267F1712005FA1FB /* ieee80211_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC482408031A007A9422 /* ieee80211_crypto.c */; };
+		17EA50D5267F1712005FA1FB /* CTimeout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC492408031A007A9422 /* CTimeout.cpp */; };
+		17EA50D6267F1712005FA1FB /* ieee80211_regdomain.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4B2408031A007A9422 /* ieee80211_regdomain.c */; };
+		17EA50D7267F1712005FA1FB /* ieee80211_node.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4C2408031A007A9422 /* ieee80211_node.c */; };
+		17EA50D8267F1712005FA1FB /* ieee80211_pae_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4D2408031A007A9422 /* ieee80211_pae_output.c */; };
+		17EA50D9267F1712005FA1FB /* sha1-pbkdf2.c in Sources */ = {isa = PBXBuildFile; fileRef = F88D2B3B2414E64000BBE700 /* sha1-pbkdf2.c */; };
+		17EA50DA267F1712005FA1FB /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07C923FCBC6C009FBA6C /* aes.c */; };
+		17EA50DB267F1712005FA1FB /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CA23FCBC6C009FBA6C /* hmac.c */; };
+		17EA50DC267F1712005FA1FB /* sha2.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CB23FCBC6C009FBA6C /* sha2.c */; };
+		17EA50DD267F1712005FA1FB /* rijndael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CC23FCBC6C009FBA6C /* rijndael.c */; };
+		17EA50DE267F1712005FA1FB /* ecb3_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CD23FCBC6C009FBA6C /* ecb3_enc.c */; };
+		17EA50DF267F1712005FA1FB /* set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CE23FCBC6C009FBA6C /* set_key.c */; };
+		17EA50E0267F1712005FA1FB /* cast.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CF23FCBC6C009FBA6C /* cast.c */; };
+		17EA50E1267F1712005FA1FB /* michael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D123FCBC6C009FBA6C /* michael.c */; };
+		17EA50E2267F1712005FA1FB /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D823FCBC6C009FBA6C /* sha1.c */; };
+		17EA50E3267F1712005FA1FB /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
+		17EA50E4267F1712005FA1FB /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
+		17EA50E5267F1712005FA1FB /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
+		17EA50E6267F1712005FA1FB /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
+		17EA50E7267F1712005FA1FB /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
+		17EA50E8267F1712005FA1FB /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
+		17EA50E9267F1712005FA1FB /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07ED23FCBC6C009FBA6C /* poly1305.c */; };
+		17EA50EA267F1712005FA1FB /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F023FCBC6C009FBA6C /* key_wrap.c */; };
+		17EA50EB267F1712005FA1FB /* gmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F223FCBC6C009FBA6C /* gmac.c */; };
+		17EA50EC267F1712005FA1FB /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F323FCBC6C009FBA6C /* rmd160.c */; };
+		17EA50ED267F1712005FA1FB /* idgen.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F423FCBC6C009FBA6C /* idgen.c */; };
+		17EA50EE267F1712005FA1FB /* compat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A07BA23FCBC6C009FBA6C /* compat.cpp */; };
+		17EA50EF267F1712005FA1FB /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F8FA0EED2501E8C100B1822E /* zutil.c */; };
+		17EA50F0267F1712005FA1FB /* ItlHalService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D364F624F93AFD0029340B /* ItlHalService.cpp */; };
+		17EA50F1267F1712005FA1FB /* ItlIwx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D6CD642442E8F200D2A454 /* ItlIwx.cpp */; };
+		17EA50F2267F1712005FA1FB /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BF23FCD4E2009FBA6C /* utils.cpp */; };
+		17EA50F3267F1712005FA1FB /* fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BD23FCD314009FBA6C /* fw.cpp */; };
+		17EA50F4267F1712005FA1FB /* io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C123FCD999009FBA6C /* io.cpp */; };
+		17EA50F5267F1712005FA1FB /* rx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C323FCDC14009FBA6C /* rx.cpp */; };
+		17EA50F6267F1712005FA1FB /* tx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C523FCDC3B009FBA6C /* tx.cpp */; };
+		17EA50F7267F1712005FA1FB /* hw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C723FCE2ED009FBA6C /* hw.cpp */; };
+		17EA50F8267F1712005FA1FB /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
+		17EA50F9267F1712005FA1FB /* phy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C923FCE537009FBA6C /* phy.cpp */; };
+		17EA50FA267F1712005FA1FB /* mac80211.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CB23FCE5CA009FBA6C /* mac80211.cpp */; };
+		17EA50FB267F1712005FA1FB /* nvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CD23FCE67F009FBA6C /* nvm.cpp */; };
+		17EA50FC267F1712005FA1FB /* ctxt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CF23FCEE88009FBA6C /* ctxt.cpp */; };
+		17EA50FD267F1712005FA1FB /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
+		17EA50FE267F1712005FA1FB /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
+		17EA50FF267F1712005FA1FB /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		17EA5100267F1712005FA1FB /* ItlIwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8AF3A2F24F9F35B008911C1 /* ItlIwm.cpp */; };
+		17EA5101267F1712005FA1FB /* AirportSTAIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDC25022F8C000F77FF /* AirportSTAIOCTL.cpp */; };
+		17EA5102267F1712005FA1FB /* AirportItlwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BBD25021C9C000F77FF /* AirportItlwm.cpp */; };
+		17EA5103267F1712005FA1FB /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
+		17EA5104267F1712005FA1FB /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
+		17EA5106267F1712005FA1FB /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5088ECBC252884870068A63D /* libkmod.a */; };
+		17EA5111267F205F005FA1FB /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6C2225027609000F77FF /* debug.h */; };
+		17EA5112267F205F005FA1FB /* IOSkywalkEthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD025021E66000F77FF /* IOSkywalkEthernetInterface.h */; };
+		17EA5113267F205F005FA1FB /* apple80211_ioctl.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC525021DEC000F77FF /* apple80211_ioctl.h */; };
+		17EA5114267F205F005FA1FB /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA36252D834500520FD4 /* IO80211P2PInterface.h */; };
+		17EA5115267F205F005FA1FB /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA39252D834500520FD4 /* IO80211WorkLoop.h */; };
+		17EA5116267F205F005FA1FB /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
+		17EA5117267F205F005FA1FB /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
+		17EA5118267F205F005FA1FB /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA38252D834500520FD4 /* IO80211Interface.h */; };
+		17EA5119267F205F005FA1FB /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA37252D834500520FD4 /* IO80211SkywalkInterface.h */; };
+		17EA511A267F205F005FA1FB /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
+		17EA511B267F205F005FA1FB /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA34252D834500520FD4 /* IO80211VirtualInterface.h */; };
+		17EA511C267F205F005FA1FB /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA35252D834500520FD4 /* IO80211Controller.h */; };
+		17EA511D267F205F005FA1FB /* ieee80211_ra.h in Headers */ = {isa = PBXBuildFile; fileRef = F8C594D225FD935B0007D19C /* ieee80211_ra.h */; };
+		17EA511E267F205F005FA1FB /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
+		17EA5120267F205F005FA1FB /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
+		17EA5121267F205F005FA1FB /* ieee80211_ra.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C594D125FD935B0007D19C /* ieee80211_ra.c */; };
+		17EA5122267F205F005FA1FB /* _task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8F9EDE0240B7415009CB8E7 /* _task.cpp */; };
+		17EA5123267F205F005FA1FB /* FwBinary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5076FA7F24CC71E40011B2BB /* FwBinary.cpp */; };
+		17EA5124267F205F005FA1FB /* IOTaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8A33572244AED060039DA12 /* IOTaskQueue.cpp */; };
+		17EA5125267F205F005FA1FB /* ieee80211_proto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC2F24080319007A9422 /* ieee80211_proto.c */; };
+		17EA5126267F205F005FA1FB /* AirportItlwmInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8CA44A125091AF60036119A /* AirportItlwmInterface.cpp */; };
+		17EA5127267F205F005FA1FB /* _string.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3024080319007A9422 /* _string.c */; };
+		17EA5128267F205F005FA1FB /* ieee80211_ioctl.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3224080319007A9422 /* ieee80211_ioctl.c */; };
+		17EA5129267F205F005FA1FB /* ieee80211.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3324080319007A9422 /* ieee80211.c */; };
+		17EA512A267F205F005FA1FB /* ieee80211_rssadapt.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3424080319007A9422 /* ieee80211_rssadapt.c */; };
+		17EA512B267F205F005FA1FB /* ieee80211_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3524080319007A9422 /* ieee80211_input.c */; };
+		17EA512C267F205F005FA1FB /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3724080319007A9422 /* timeout.c */; };
+		17EA512D267F205F005FA1FB /* ieee80211_mira.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3924080319007A9422 /* ieee80211_mira.c */; };
+		17EA512E267F205F005FA1FB /* ieee80211_crypto_bip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3B24080319007A9422 /* ieee80211_crypto_bip.c */; };
+		17EA512F267F205F005FA1FB /* ieee80211_crypto_tkip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3C24080319007A9422 /* ieee80211_crypto_tkip.c */; };
+		17EA5130267F205F005FA1FB /* ieee80211_crypto_ccmp.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3D24080319007A9422 /* ieee80211_crypto_ccmp.c */; };
+		17EA5131267F205F005FA1FB /* ieee80211_crypto_wep.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC462408031A007A9422 /* ieee80211_crypto_wep.c */; };
+		17EA5132267F205F005FA1FB /* ieee80211_pae_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3E24080319007A9422 /* ieee80211_pae_input.c */; };
+		17EA5133267F205F005FA1FB /* ieee80211_amrr.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4024080319007A9422 /* ieee80211_amrr.c */; };
+		17EA5134267F205F005FA1FB /* ieee80211_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC472408031A007A9422 /* ieee80211_output.c */; };
+		17EA5135267F205F005FA1FB /* ieee80211_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC482408031A007A9422 /* ieee80211_crypto.c */; };
+		17EA5136267F205F005FA1FB /* CTimeout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC492408031A007A9422 /* CTimeout.cpp */; };
+		17EA5137267F205F005FA1FB /* ieee80211_regdomain.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4B2408031A007A9422 /* ieee80211_regdomain.c */; };
+		17EA5138267F205F005FA1FB /* ieee80211_node.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4C2408031A007A9422 /* ieee80211_node.c */; };
+		17EA5139267F205F005FA1FB /* ieee80211_pae_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4D2408031A007A9422 /* ieee80211_pae_output.c */; };
+		17EA513A267F205F005FA1FB /* sha1-pbkdf2.c in Sources */ = {isa = PBXBuildFile; fileRef = F88D2B3B2414E64000BBE700 /* sha1-pbkdf2.c */; };
+		17EA513B267F205F005FA1FB /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07C923FCBC6C009FBA6C /* aes.c */; };
+		17EA513C267F205F005FA1FB /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CA23FCBC6C009FBA6C /* hmac.c */; };
+		17EA513D267F205F005FA1FB /* sha2.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CB23FCBC6C009FBA6C /* sha2.c */; };
+		17EA513E267F205F005FA1FB /* rijndael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CC23FCBC6C009FBA6C /* rijndael.c */; };
+		17EA513F267F205F005FA1FB /* ecb3_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CD23FCBC6C009FBA6C /* ecb3_enc.c */; };
+		17EA5140267F205F005FA1FB /* set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CE23FCBC6C009FBA6C /* set_key.c */; };
+		17EA5141267F205F005FA1FB /* cast.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CF23FCBC6C009FBA6C /* cast.c */; };
+		17EA5142267F205F005FA1FB /* michael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D123FCBC6C009FBA6C /* michael.c */; };
+		17EA5143267F205F005FA1FB /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D823FCBC6C009FBA6C /* sha1.c */; };
+		17EA5144267F205F005FA1FB /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
+		17EA5145267F205F005FA1FB /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
+		17EA5146267F205F005FA1FB /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
+		17EA5147267F205F005FA1FB /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
+		17EA5148267F205F005FA1FB /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
+		17EA5149267F205F005FA1FB /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
+		17EA514A267F205F005FA1FB /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07ED23FCBC6C009FBA6C /* poly1305.c */; };
+		17EA514B267F205F005FA1FB /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F023FCBC6C009FBA6C /* key_wrap.c */; };
+		17EA514C267F205F005FA1FB /* gmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F223FCBC6C009FBA6C /* gmac.c */; };
+		17EA514D267F205F005FA1FB /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F323FCBC6C009FBA6C /* rmd160.c */; };
+		17EA514E267F205F005FA1FB /* idgen.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F423FCBC6C009FBA6C /* idgen.c */; };
+		17EA514F267F205F005FA1FB /* compat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A07BA23FCBC6C009FBA6C /* compat.cpp */; };
+		17EA5150267F205F005FA1FB /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F8FA0EED2501E8C100B1822E /* zutil.c */; };
+		17EA5151267F205F005FA1FB /* ItlHalService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D364F624F93AFD0029340B /* ItlHalService.cpp */; };
+		17EA5152267F205F005FA1FB /* ItlIwx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D6CD642442E8F200D2A454 /* ItlIwx.cpp */; };
+		17EA5153267F205F005FA1FB /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BF23FCD4E2009FBA6C /* utils.cpp */; };
+		17EA5154267F205F005FA1FB /* fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BD23FCD314009FBA6C /* fw.cpp */; };
+		17EA5155267F205F005FA1FB /* io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C123FCD999009FBA6C /* io.cpp */; };
+		17EA5156267F205F005FA1FB /* rx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C323FCDC14009FBA6C /* rx.cpp */; };
+		17EA5157267F205F005FA1FB /* tx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C523FCDC3B009FBA6C /* tx.cpp */; };
+		17EA5158267F205F005FA1FB /* hw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C723FCE2ED009FBA6C /* hw.cpp */; };
+		17EA5159267F205F005FA1FB /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
+		17EA515A267F205F005FA1FB /* phy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C923FCE537009FBA6C /* phy.cpp */; };
+		17EA515B267F205F005FA1FB /* mac80211.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CB23FCE5CA009FBA6C /* mac80211.cpp */; };
+		17EA515C267F205F005FA1FB /* nvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CD23FCE67F009FBA6C /* nvm.cpp */; };
+		17EA515D267F205F005FA1FB /* ctxt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CF23FCEE88009FBA6C /* ctxt.cpp */; };
+		17EA515E267F205F005FA1FB /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
+		17EA515F267F205F005FA1FB /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
+		17EA5160267F205F005FA1FB /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		17EA5161267F205F005FA1FB /* ItlIwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8AF3A2F24F9F35B008911C1 /* ItlIwm.cpp */; };
+		17EA5162267F205F005FA1FB /* AirportSTAIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDC25022F8C000F77FF /* AirportSTAIOCTL.cpp */; };
+		17EA5163267F205F005FA1FB /* AirportItlwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BBD25021C9C000F77FF /* AirportItlwm.cpp */; };
+		17EA5164267F205F005FA1FB /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
+		17EA5165267F205F005FA1FB /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
+		17EA5167267F205F005FA1FB /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5088ECBC252884870068A63D /* libkmod.a */; };
 		17FD7F10255E4AC800611406 /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
 		17FD7F11255E4AC800611406 /* ItlIwn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 17FD7F0F255E4AC800611406 /* ItlIwn.hpp */; };
 		17FD7F63255E547100611406 /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
@@ -681,6 +851,20 @@
 			remoteGlobalIDString = 5066D63825287F7900EE6F38;
 			remoteInfo = fw_gen;
 		};
+		17EA50AE267F1712005FA1FB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5066D63825287F7900EE6F38;
+			remoteInfo = fw_gen;
+		};
+		17EA510F267F205F005FA1FB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5066D63825287F7900EE6F38;
+			remoteInfo = fw_gen;
+		};
 		5066D63D252880A700EE6F38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
@@ -793,6 +977,8 @@
 		024A08D323FCF3E6009FBA6C /* power.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = power.cpp; sourceTree = "<group>"; };
 		024A08D523FCF4D7009FBA6C /* scan.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = scan.cpp; sourceTree = "<group>"; };
 		1776949F26578D930019558D /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		17EA510B267F1712005FA1FB /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		17EA516C267F205F005FA1FB /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		17FD7F0C255E4A0900611406 /* if_iwnvar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = if_iwnvar.h; sourceTree = "<group>"; };
 		17FD7F0D255E4AB000611406 /* if_iwnreg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = if_iwnreg.h; sourceTree = "<group>"; };
 		17FD7F0E255E4AC800611406 /* ItlIwn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ItlIwn.cpp; sourceTree = "<group>"; };
@@ -958,6 +1144,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		17EA5105267F1712005FA1FB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17EA5106267F1712005FA1FB /* libkmod.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17EA5166267F205F005FA1FB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17EA5167267F205F005FA1FB /* libkmod.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		35CBE6B5251CB89700435CBC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1026,6 +1228,8 @@
 				35CBE78F251CB8CA00435CBC /* AirportItlwm.kext */,
 				F897ED18266EFF93005EE8F7 /* AirportItlwm.kext */,
 				1776949F26578D930019558D /* AirportItlwm.kext */,
+				17EA510B267F1712005FA1FB /* AirportItlwm.kext */,
+				17EA516C267F205F005FA1FB /* AirportItlwm.kext */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1464,6 +1668,48 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		17EA50AF267F1712005FA1FB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17EA50B0267F1712005FA1FB /* debug.h in Headers */,
+				17EA50B1267F1712005FA1FB /* IOSkywalkEthernetInterface.h in Headers */,
+				17EA50B2267F1712005FA1FB /* apple80211_ioctl.h in Headers */,
+				17EA50B3267F1712005FA1FB /* IO80211P2PInterface.h in Headers */,
+				17EA50B4267F1712005FA1FB /* IO80211WorkLoop.h in Headers */,
+				17EA50B5267F1712005FA1FB /* apple80211_var.h in Headers */,
+				17EA50B6267F1712005FA1FB /* AirportItlwmInterface.hpp in Headers */,
+				17EA50B7267F1712005FA1FB /* IO80211Interface.h in Headers */,
+				17EA50B8267F1712005FA1FB /* IO80211SkywalkInterface.h in Headers */,
+				17EA50B9267F1712005FA1FB /* AirportItlwm.hpp in Headers */,
+				17EA50BA267F1712005FA1FB /* IO80211VirtualInterface.h in Headers */,
+				17EA50BB267F1712005FA1FB /* IO80211Controller.h in Headers */,
+				17EA50BC267F1712005FA1FB /* ieee80211_ra.h in Headers */,
+				17EA50BD267F1712005FA1FB /* apple80211_wps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17EA5110267F205F005FA1FB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17EA5111267F205F005FA1FB /* debug.h in Headers */,
+				17EA5112267F205F005FA1FB /* IOSkywalkEthernetInterface.h in Headers */,
+				17EA5113267F205F005FA1FB /* apple80211_ioctl.h in Headers */,
+				17EA5114267F205F005FA1FB /* IO80211P2PInterface.h in Headers */,
+				17EA5115267F205F005FA1FB /* IO80211WorkLoop.h in Headers */,
+				17EA5116267F205F005FA1FB /* apple80211_var.h in Headers */,
+				17EA5117267F205F005FA1FB /* AirportItlwmInterface.hpp in Headers */,
+				17EA5118267F205F005FA1FB /* IO80211Interface.h in Headers */,
+				17EA5119267F205F005FA1FB /* IO80211SkywalkInterface.h in Headers */,
+				17EA511A267F205F005FA1FB /* AirportItlwm.hpp in Headers */,
+				17EA511B267F205F005FA1FB /* IO80211VirtualInterface.h in Headers */,
+				17EA511C267F205F005FA1FB /* IO80211Controller.h in Headers */,
+				17EA511D267F205F005FA1FB /* ieee80211_ra.h in Headers */,
+				17EA511E267F205F005FA1FB /* apple80211_wps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		35CBE658251CB89700435CBC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1610,6 +1856,44 @@
 			productReference = 1776949F26578D930019558D /* AirportItlwm.kext */;
 			productType = "com.apple.product-type.kernel-extension";
 		};
+		17EA50AC267F1712005FA1FB /* AirportItlwm-El Captain */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17EA5108267F1712005FA1FB /* Build configuration list for PBXNativeTarget "AirportItlwm-El Captain" */;
+			buildPhases = (
+				17EA50AF267F1712005FA1FB /* Headers */,
+				17EA50BE267F1712005FA1FB /* Sources */,
+				17EA5105267F1712005FA1FB /* Frameworks */,
+				17EA5107267F1712005FA1FB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				17EA50AD267F1712005FA1FB /* PBXTargetDependency */,
+			);
+			name = "AirportItlwm-El Captain";
+			productName = AirportItlwm;
+			productReference = 17EA510B267F1712005FA1FB /* AirportItlwm.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		17EA510D267F205F005FA1FB /* AirportItlwm-Yosemite */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17EA5169267F205F005FA1FB /* Build configuration list for PBXNativeTarget "AirportItlwm-Yosemite" */;
+			buildPhases = (
+				17EA5110267F205F005FA1FB /* Headers */,
+				17EA511F267F205F005FA1FB /* Sources */,
+				17EA5166267F205F005FA1FB /* Frameworks */,
+				17EA5168267F205F005FA1FB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				17EA510E267F205F005FA1FB /* PBXTargetDependency */,
+			);
+			name = "AirportItlwm-Yosemite";
+			productName = AirportItlwm;
+			productReference = 17EA516C267F205F005FA1FB /* AirportItlwm.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
 		35CBE655251CB89700435CBC /* AirportItlwm-Big Sur */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 35CBE6B7251CB89700435CBC /* Build configuration list for PBXNativeTarget "AirportItlwm-Big Sur" */;
@@ -1721,6 +2005,12 @@
 					1776943D26578D930019558D = {
 						ProvisioningStyle = Manual;
 					};
+					17EA50AC267F1712005FA1FB = {
+						ProvisioningStyle = Manual;
+					};
+					17EA510D267F205F005FA1FB = {
+						ProvisioningStyle = Manual;
+					};
 					35CBE655251CB89700435CBC = {
 						ProvisioningStyle = Manual;
 					};
@@ -1757,6 +2047,8 @@
 			projectRoot = "";
 			targets = (
 				024A07AB23FCBC3C009FBA6C /* itlwm */,
+				17EA510D267F205F005FA1FB /* AirportItlwm-Yosemite */,
+				17EA50AC267F1712005FA1FB /* AirportItlwm-El Captain */,
 				1776943D26578D930019558D /* AirportItlwm-Sierra */,
 				35CBE72A251CB8CA00435CBC /* AirportItlwm-High Sierra */,
 				35CBE6BF251CB8BF00435CBC /* AirportItlwm-Mojave */,
@@ -1778,6 +2070,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1776949B26578D930019558D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17EA5107267F1712005FA1FB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17EA5168267F205F005FA1FB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1994,6 +2300,160 @@
 				1776949626578D930019558D /* AirportItlwm.cpp in Sources */,
 				1776949726578D930019558D /* AirportVirtualIOCTL.cpp in Sources */,
 				1776949826578D930019558D /* AirportAWDL.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17EA50BE267F1712005FA1FB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17EA50BF267F1712005FA1FB /* _mbuf.cpp in Sources */,
+				17EA50C0267F1712005FA1FB /* ieee80211_ra.c in Sources */,
+				17EA50C1267F1712005FA1FB /* _task.cpp in Sources */,
+				17EA50C2267F1712005FA1FB /* FwBinary.cpp in Sources */,
+				17EA50C3267F1712005FA1FB /* IOTaskQueue.cpp in Sources */,
+				17EA50C4267F1712005FA1FB /* ieee80211_proto.c in Sources */,
+				17EA50C5267F1712005FA1FB /* AirportItlwmInterface.cpp in Sources */,
+				17EA50C6267F1712005FA1FB /* _string.c in Sources */,
+				17EA50C7267F1712005FA1FB /* ieee80211_ioctl.c in Sources */,
+				17EA50C8267F1712005FA1FB /* ieee80211.c in Sources */,
+				17EA50C9267F1712005FA1FB /* ieee80211_rssadapt.c in Sources */,
+				17EA50CA267F1712005FA1FB /* ieee80211_input.c in Sources */,
+				17EA50CB267F1712005FA1FB /* timeout.c in Sources */,
+				17EA50CC267F1712005FA1FB /* ieee80211_mira.c in Sources */,
+				17EA50CD267F1712005FA1FB /* ieee80211_crypto_bip.c in Sources */,
+				17EA50CE267F1712005FA1FB /* ieee80211_crypto_tkip.c in Sources */,
+				17EA50CF267F1712005FA1FB /* ieee80211_crypto_ccmp.c in Sources */,
+				17EA50D0267F1712005FA1FB /* ieee80211_crypto_wep.c in Sources */,
+				17EA50D1267F1712005FA1FB /* ieee80211_pae_input.c in Sources */,
+				17EA50D2267F1712005FA1FB /* ieee80211_amrr.c in Sources */,
+				17EA50D3267F1712005FA1FB /* ieee80211_output.c in Sources */,
+				17EA50D4267F1712005FA1FB /* ieee80211_crypto.c in Sources */,
+				17EA50D5267F1712005FA1FB /* CTimeout.cpp in Sources */,
+				17EA50D6267F1712005FA1FB /* ieee80211_regdomain.c in Sources */,
+				17EA50D7267F1712005FA1FB /* ieee80211_node.c in Sources */,
+				17EA50D8267F1712005FA1FB /* ieee80211_pae_output.c in Sources */,
+				17EA50D9267F1712005FA1FB /* sha1-pbkdf2.c in Sources */,
+				17EA50DA267F1712005FA1FB /* aes.c in Sources */,
+				17EA50DB267F1712005FA1FB /* hmac.c in Sources */,
+				17EA50DC267F1712005FA1FB /* sha2.c in Sources */,
+				17EA50DD267F1712005FA1FB /* rijndael.c in Sources */,
+				17EA50DE267F1712005FA1FB /* ecb3_enc.c in Sources */,
+				17EA50DF267F1712005FA1FB /* set_key.c in Sources */,
+				17EA50E0267F1712005FA1FB /* cast.c in Sources */,
+				17EA50E1267F1712005FA1FB /* michael.c in Sources */,
+				17EA50E2267F1712005FA1FB /* sha1.c in Sources */,
+				17EA50E3267F1712005FA1FB /* cmac.c in Sources */,
+				17EA50E4267F1712005FA1FB /* ecb_enc.c in Sources */,
+				17EA50E5267F1712005FA1FB /* chachapoly.c in Sources */,
+				17EA50E6267F1712005FA1FB /* md5.c in Sources */,
+				17EA50E7267F1712005FA1FB /* arc4.c in Sources */,
+				17EA50E8267F1712005FA1FB /* blf.c in Sources */,
+				17EA50E9267F1712005FA1FB /* poly1305.c in Sources */,
+				17EA50EA267F1712005FA1FB /* key_wrap.c in Sources */,
+				17EA50EB267F1712005FA1FB /* gmac.c in Sources */,
+				17EA50EC267F1712005FA1FB /* rmd160.c in Sources */,
+				17EA50ED267F1712005FA1FB /* idgen.c in Sources */,
+				17EA50EE267F1712005FA1FB /* compat.cpp in Sources */,
+				17EA50EF267F1712005FA1FB /* zutil.c in Sources */,
+				17EA50F0267F1712005FA1FB /* ItlHalService.cpp in Sources */,
+				17EA50F1267F1712005FA1FB /* ItlIwx.cpp in Sources */,
+				17EA50F2267F1712005FA1FB /* utils.cpp in Sources */,
+				17EA50F3267F1712005FA1FB /* fw.cpp in Sources */,
+				17EA50F4267F1712005FA1FB /* io.cpp in Sources */,
+				17EA50F5267F1712005FA1FB /* rx.cpp in Sources */,
+				17EA50F6267F1712005FA1FB /* tx.cpp in Sources */,
+				17EA50F7267F1712005FA1FB /* hw.cpp in Sources */,
+				17EA50F8267F1712005FA1FB /* ItlIwn.cpp in Sources */,
+				17EA50F9267F1712005FA1FB /* phy.cpp in Sources */,
+				17EA50FA267F1712005FA1FB /* mac80211.cpp in Sources */,
+				17EA50FB267F1712005FA1FB /* nvm.cpp in Sources */,
+				17EA50FC267F1712005FA1FB /* ctxt.cpp in Sources */,
+				17EA50FD267F1712005FA1FB /* led.cpp in Sources */,
+				17EA50FE267F1712005FA1FB /* power.cpp in Sources */,
+				17EA50FF267F1712005FA1FB /* scan.cpp in Sources */,
+				17EA5100267F1712005FA1FB /* ItlIwm.cpp in Sources */,
+				17EA5101267F1712005FA1FB /* AirportSTAIOCTL.cpp in Sources */,
+				17EA5102267F1712005FA1FB /* AirportItlwm.cpp in Sources */,
+				17EA5103267F1712005FA1FB /* AirportVirtualIOCTL.cpp in Sources */,
+				17EA5104267F1712005FA1FB /* AirportAWDL.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		17EA511F267F205F005FA1FB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				17EA5120267F205F005FA1FB /* _mbuf.cpp in Sources */,
+				17EA5121267F205F005FA1FB /* ieee80211_ra.c in Sources */,
+				17EA5122267F205F005FA1FB /* _task.cpp in Sources */,
+				17EA5123267F205F005FA1FB /* FwBinary.cpp in Sources */,
+				17EA5124267F205F005FA1FB /* IOTaskQueue.cpp in Sources */,
+				17EA5125267F205F005FA1FB /* ieee80211_proto.c in Sources */,
+				17EA5126267F205F005FA1FB /* AirportItlwmInterface.cpp in Sources */,
+				17EA5127267F205F005FA1FB /* _string.c in Sources */,
+				17EA5128267F205F005FA1FB /* ieee80211_ioctl.c in Sources */,
+				17EA5129267F205F005FA1FB /* ieee80211.c in Sources */,
+				17EA512A267F205F005FA1FB /* ieee80211_rssadapt.c in Sources */,
+				17EA512B267F205F005FA1FB /* ieee80211_input.c in Sources */,
+				17EA512C267F205F005FA1FB /* timeout.c in Sources */,
+				17EA512D267F205F005FA1FB /* ieee80211_mira.c in Sources */,
+				17EA512E267F205F005FA1FB /* ieee80211_crypto_bip.c in Sources */,
+				17EA512F267F205F005FA1FB /* ieee80211_crypto_tkip.c in Sources */,
+				17EA5130267F205F005FA1FB /* ieee80211_crypto_ccmp.c in Sources */,
+				17EA5131267F205F005FA1FB /* ieee80211_crypto_wep.c in Sources */,
+				17EA5132267F205F005FA1FB /* ieee80211_pae_input.c in Sources */,
+				17EA5133267F205F005FA1FB /* ieee80211_amrr.c in Sources */,
+				17EA5134267F205F005FA1FB /* ieee80211_output.c in Sources */,
+				17EA5135267F205F005FA1FB /* ieee80211_crypto.c in Sources */,
+				17EA5136267F205F005FA1FB /* CTimeout.cpp in Sources */,
+				17EA5137267F205F005FA1FB /* ieee80211_regdomain.c in Sources */,
+				17EA5138267F205F005FA1FB /* ieee80211_node.c in Sources */,
+				17EA5139267F205F005FA1FB /* ieee80211_pae_output.c in Sources */,
+				17EA513A267F205F005FA1FB /* sha1-pbkdf2.c in Sources */,
+				17EA513B267F205F005FA1FB /* aes.c in Sources */,
+				17EA513C267F205F005FA1FB /* hmac.c in Sources */,
+				17EA513D267F205F005FA1FB /* sha2.c in Sources */,
+				17EA513E267F205F005FA1FB /* rijndael.c in Sources */,
+				17EA513F267F205F005FA1FB /* ecb3_enc.c in Sources */,
+				17EA5140267F205F005FA1FB /* set_key.c in Sources */,
+				17EA5141267F205F005FA1FB /* cast.c in Sources */,
+				17EA5142267F205F005FA1FB /* michael.c in Sources */,
+				17EA5143267F205F005FA1FB /* sha1.c in Sources */,
+				17EA5144267F205F005FA1FB /* cmac.c in Sources */,
+				17EA5145267F205F005FA1FB /* ecb_enc.c in Sources */,
+				17EA5146267F205F005FA1FB /* chachapoly.c in Sources */,
+				17EA5147267F205F005FA1FB /* md5.c in Sources */,
+				17EA5148267F205F005FA1FB /* arc4.c in Sources */,
+				17EA5149267F205F005FA1FB /* blf.c in Sources */,
+				17EA514A267F205F005FA1FB /* poly1305.c in Sources */,
+				17EA514B267F205F005FA1FB /* key_wrap.c in Sources */,
+				17EA514C267F205F005FA1FB /* gmac.c in Sources */,
+				17EA514D267F205F005FA1FB /* rmd160.c in Sources */,
+				17EA514E267F205F005FA1FB /* idgen.c in Sources */,
+				17EA514F267F205F005FA1FB /* compat.cpp in Sources */,
+				17EA5150267F205F005FA1FB /* zutil.c in Sources */,
+				17EA5151267F205F005FA1FB /* ItlHalService.cpp in Sources */,
+				17EA5152267F205F005FA1FB /* ItlIwx.cpp in Sources */,
+				17EA5153267F205F005FA1FB /* utils.cpp in Sources */,
+				17EA5154267F205F005FA1FB /* fw.cpp in Sources */,
+				17EA5155267F205F005FA1FB /* io.cpp in Sources */,
+				17EA5156267F205F005FA1FB /* rx.cpp in Sources */,
+				17EA5157267F205F005FA1FB /* tx.cpp in Sources */,
+				17EA5158267F205F005FA1FB /* hw.cpp in Sources */,
+				17EA5159267F205F005FA1FB /* ItlIwn.cpp in Sources */,
+				17EA515A267F205F005FA1FB /* phy.cpp in Sources */,
+				17EA515B267F205F005FA1FB /* mac80211.cpp in Sources */,
+				17EA515C267F205F005FA1FB /* nvm.cpp in Sources */,
+				17EA515D267F205F005FA1FB /* ctxt.cpp in Sources */,
+				17EA515E267F205F005FA1FB /* led.cpp in Sources */,
+				17EA515F267F205F005FA1FB /* power.cpp in Sources */,
+				17EA5160267F205F005FA1FB /* scan.cpp in Sources */,
+				17EA5161267F205F005FA1FB /* ItlIwm.cpp in Sources */,
+				17EA5162267F205F005FA1FB /* AirportSTAIOCTL.cpp in Sources */,
+				17EA5163267F205F005FA1FB /* AirportItlwm.cpp in Sources */,
+				17EA5164267F205F005FA1FB /* AirportVirtualIOCTL.cpp in Sources */,
+				17EA5165267F205F005FA1FB /* AirportAWDL.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2390,6 +2850,16 @@
 			target = 5066D63825287F7900EE6F38 /* fw_gen */;
 			targetProxy = 1776943F26578D930019558D /* PBXContainerItemProxy */;
 		};
+		17EA50AD267F1712005FA1FB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5066D63825287F7900EE6F38 /* fw_gen */;
+			targetProxy = 17EA50AE267F1712005FA1FB /* PBXContainerItemProxy */;
+		};
+		17EA510E267F205F005FA1FB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5066D63825287F7900EE6F38 /* fw_gen */;
+			targetProxy = 17EA510F267F205F005FA1FB /* PBXContainerItemProxy */;
+		};
 		5066D63E252880A700EE6F38 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5066D63825287F7900EE6F38 /* fw_gen */;
@@ -2665,6 +3135,126 @@
 					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		17EA5109267F1712005FA1FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/$(CONFIGURATION)/El Captain";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = itlwm/PrivateSPI.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					USE_APPLE_SUPPLICANT,
+					AIRPORT,
+					"__IO80211_TARGET=__MAC_10_11",
+					__PRIVATE_SPI__,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		17EA510A267F1712005FA1FB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/$(CONFIGURATION)/El Captain";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = itlwm/PrivateSPI.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"__IO80211_TARGET=__MAC_10_11",
+					USE_APPLE_SUPPLICANT,
+					AIRPORT,
+					__PRIVATE_SPI__,
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		17EA516A267F205F005FA1FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/$(CONFIGURATION)/Yosemite";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = itlwm/PrivateSPI.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					USE_APPLE_SUPPLICANT,
+					AIRPORT,
+					"__IO80211_TARGET=__MAC_10_10",
+					__PRIVATE_SPI__,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		17EA516B267F205F005FA1FB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/$(CONFIGURATION)/Yosemite";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = itlwm/PrivateSPI.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"__IO80211_TARGET=__MAC_10_10",
+					USE_APPLE_SUPPLICANT,
+					AIRPORT,
+					__PRIVATE_SPI__,
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MODULE_NAME = com.zxystd.AirportItlwm;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
 				PRODUCT_NAME = AirportItlwm;
@@ -3021,6 +3611,24 @@
 			buildConfigurations = (
 				1776949D26578D930019558D /* Debug */,
 				1776949E26578D930019558D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		17EA5108267F1712005FA1FB /* Build configuration list for PBXNativeTarget "AirportItlwm-El Captain" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17EA5109267F1712005FA1FB /* Debug */,
+				17EA510A267F1712005FA1FB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		17EA5169267F205F005FA1FB /* Build configuration list for PBXNativeTarget "AirportItlwm-Yosemite" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				17EA516A267F205F005FA1FB /* Debug */,
+				17EA516B267F205F005FA1FB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/itlwm.xcodeproj/project.pbxproj
+++ b/itlwm.xcodeproj/project.pbxproj
@@ -82,6 +82,91 @@
 		024A08D223FCF395009FBA6C /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
 		024A08D423FCF3E6009FBA6C /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
 		024A08D623FCF4D7009FBA6C /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		1776944126578D930019558D /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6C2225027609000F77FF /* debug.h */; };
+		1776944226578D930019558D /* IOSkywalkEthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BD025021E66000F77FF /* IOSkywalkEthernetInterface.h */; };
+		1776944326578D930019558D /* apple80211_ioctl.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC525021DEC000F77FF /* apple80211_ioctl.h */; };
+		1776944426578D930019558D /* IO80211P2PInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA36252D834500520FD4 /* IO80211P2PInterface.h */; };
+		1776944526578D930019558D /* IO80211WorkLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA39252D834500520FD4 /* IO80211WorkLoop.h */; };
+		1776944626578D930019558D /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
+		1776944726578D930019558D /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
+		1776944826578D930019558D /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA38252D834500520FD4 /* IO80211Interface.h */; };
+		1776944A26578D930019558D /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA37252D834500520FD4 /* IO80211SkywalkInterface.h */; };
+		1776944B26578D930019558D /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
+		1776944C26578D930019558D /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA34252D834500520FD4 /* IO80211VirtualInterface.h */; };
+		1776944D26578D930019558D /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA35252D834500520FD4 /* IO80211Controller.h */; };
+		1776944F26578D930019558D /* ieee80211_ra.h in Headers */ = {isa = PBXBuildFile; fileRef = F8C594D225FD935B0007D19C /* ieee80211_ra.h */; };
+		1776945026578D930019558D /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
+		1776945226578D930019558D /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
+		1776945326578D930019558D /* ieee80211_ra.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C594D125FD935B0007D19C /* ieee80211_ra.c */; };
+		1776945426578D930019558D /* _task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8F9EDE0240B7415009CB8E7 /* _task.cpp */; };
+		1776945526578D930019558D /* FwBinary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5076FA7F24CC71E40011B2BB /* FwBinary.cpp */; };
+		1776945626578D930019558D /* IOTaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8A33572244AED060039DA12 /* IOTaskQueue.cpp */; };
+		1776945726578D930019558D /* ieee80211_proto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC2F24080319007A9422 /* ieee80211_proto.c */; };
+		1776945826578D930019558D /* AirportItlwmInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8CA44A125091AF60036119A /* AirportItlwmInterface.cpp */; };
+		1776945926578D930019558D /* _string.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3024080319007A9422 /* _string.c */; };
+		1776945A26578D930019558D /* ieee80211_ioctl.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3224080319007A9422 /* ieee80211_ioctl.c */; };
+		1776945B26578D930019558D /* ieee80211.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3324080319007A9422 /* ieee80211.c */; };
+		1776945C26578D930019558D /* ieee80211_rssadapt.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3424080319007A9422 /* ieee80211_rssadapt.c */; };
+		1776945D26578D930019558D /* ieee80211_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3524080319007A9422 /* ieee80211_input.c */; };
+		1776945E26578D930019558D /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3724080319007A9422 /* timeout.c */; };
+		1776945F26578D930019558D /* ieee80211_mira.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3924080319007A9422 /* ieee80211_mira.c */; };
+		1776946026578D930019558D /* ieee80211_crypto_bip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3B24080319007A9422 /* ieee80211_crypto_bip.c */; };
+		1776946126578D930019558D /* ieee80211_crypto_tkip.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3C24080319007A9422 /* ieee80211_crypto_tkip.c */; };
+		1776946226578D930019558D /* ieee80211_crypto_ccmp.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3D24080319007A9422 /* ieee80211_crypto_ccmp.c */; };
+		1776946326578D930019558D /* ieee80211_crypto_wep.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC462408031A007A9422 /* ieee80211_crypto_wep.c */; };
+		1776946426578D930019558D /* ieee80211_pae_input.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC3E24080319007A9422 /* ieee80211_pae_input.c */; };
+		1776946526578D930019558D /* ieee80211_amrr.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4024080319007A9422 /* ieee80211_amrr.c */; };
+		1776946626578D930019558D /* ieee80211_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC472408031A007A9422 /* ieee80211_output.c */; };
+		1776946726578D930019558D /* ieee80211_crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC482408031A007A9422 /* ieee80211_crypto.c */; };
+		1776946826578D930019558D /* CTimeout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC492408031A007A9422 /* CTimeout.cpp */; };
+		1776946926578D930019558D /* ieee80211_regdomain.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4B2408031A007A9422 /* ieee80211_regdomain.c */; };
+		1776946A26578D930019558D /* ieee80211_node.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4C2408031A007A9422 /* ieee80211_node.c */; };
+		1776946B26578D930019558D /* ieee80211_pae_output.c in Sources */ = {isa = PBXBuildFile; fileRef = F8C2EC4D2408031A007A9422 /* ieee80211_pae_output.c */; };
+		1776946C26578D930019558D /* sha1-pbkdf2.c in Sources */ = {isa = PBXBuildFile; fileRef = F88D2B3B2414E64000BBE700 /* sha1-pbkdf2.c */; };
+		1776946D26578D930019558D /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07C923FCBC6C009FBA6C /* aes.c */; };
+		1776946E26578D930019558D /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CA23FCBC6C009FBA6C /* hmac.c */; };
+		1776946F26578D930019558D /* sha2.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CB23FCBC6C009FBA6C /* sha2.c */; };
+		1776947026578D930019558D /* rijndael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CC23FCBC6C009FBA6C /* rijndael.c */; };
+		1776947126578D930019558D /* ecb3_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CD23FCBC6C009FBA6C /* ecb3_enc.c */; };
+		1776947226578D930019558D /* set_key.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CE23FCBC6C009FBA6C /* set_key.c */; };
+		1776947326578D930019558D /* cast.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07CF23FCBC6C009FBA6C /* cast.c */; };
+		1776947426578D930019558D /* michael.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D123FCBC6C009FBA6C /* michael.c */; };
+		1776947526578D930019558D /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07D823FCBC6C009FBA6C /* sha1.c */; };
+		1776947626578D930019558D /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
+		1776947726578D930019558D /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
+		1776947826578D930019558D /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
+		1776947A26578D930019558D /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
+		1776947B26578D930019558D /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
+		1776947C26578D930019558D /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
+		1776947D26578D930019558D /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07ED23FCBC6C009FBA6C /* poly1305.c */; };
+		1776947E26578D930019558D /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F023FCBC6C009FBA6C /* key_wrap.c */; };
+		1776947F26578D930019558D /* gmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F223FCBC6C009FBA6C /* gmac.c */; };
+		1776948026578D930019558D /* rmd160.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F323FCBC6C009FBA6C /* rmd160.c */; };
+		1776948126578D930019558D /* idgen.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07F423FCBC6C009FBA6C /* idgen.c */; };
+		1776948226578D930019558D /* compat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A07BA23FCBC6C009FBA6C /* compat.cpp */; };
+		1776948326578D930019558D /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F8FA0EED2501E8C100B1822E /* zutil.c */; };
+		1776948426578D930019558D /* ItlHalService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D364F624F93AFD0029340B /* ItlHalService.cpp */; };
+		1776948526578D930019558D /* ItlIwx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D6CD642442E8F200D2A454 /* ItlIwx.cpp */; };
+		1776948626578D930019558D /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BF23FCD4E2009FBA6C /* utils.cpp */; };
+		1776948726578D930019558D /* fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08BD23FCD314009FBA6C /* fw.cpp */; };
+		1776948826578D930019558D /* io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C123FCD999009FBA6C /* io.cpp */; };
+		1776948926578D930019558D /* rx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C323FCDC14009FBA6C /* rx.cpp */; };
+		1776948A26578D930019558D /* tx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C523FCDC3B009FBA6C /* tx.cpp */; };
+		1776948B26578D930019558D /* hw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C723FCE2ED009FBA6C /* hw.cpp */; };
+		1776948C26578D930019558D /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
+		1776948D26578D930019558D /* phy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08C923FCE537009FBA6C /* phy.cpp */; };
+		1776948E26578D930019558D /* mac80211.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CB23FCE5CA009FBA6C /* mac80211.cpp */; };
+		1776948F26578D930019558D /* nvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CD23FCE67F009FBA6C /* nvm.cpp */; };
+		1776949026578D930019558D /* ctxt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08CF23FCEE88009FBA6C /* ctxt.cpp */; };
+		1776949126578D930019558D /* led.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D123FCF395009FBA6C /* led.cpp */; };
+		1776949226578D930019558D /* power.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D323FCF3E6009FBA6C /* power.cpp */; };
+		1776949326578D930019558D /* scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 024A08D523FCF4D7009FBA6C /* scan.cpp */; };
+		1776949426578D930019558D /* ItlIwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8AF3A2F24F9F35B008911C1 /* ItlIwm.cpp */; };
+		1776949526578D930019558D /* AirportSTAIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDC25022F8C000F77FF /* AirportSTAIOCTL.cpp */; };
+		1776949626578D930019558D /* AirportItlwm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BBD25021C9C000F77FF /* AirportItlwm.cpp */; };
+		1776949726578D930019558D /* AirportVirtualIOCTL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BDE25022FB5000F77FF /* AirportVirtualIOCTL.cpp */; };
+		1776949826578D930019558D /* AirportAWDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F89B6BE025022FC7000F77FF /* AirportAWDL.cpp */; };
+		1776949A26578D930019558D /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5088ECBC252884870068A63D /* libkmod.a */; };
 		17FD7F10255E4AC800611406 /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
 		17FD7F11255E4AC800611406 /* ItlIwn.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 17FD7F0F255E4AC800611406 /* ItlIwn.hpp */; };
 		17FD7F63255E547100611406 /* ItlIwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 17FD7F0E255E4AC800611406 /* ItlIwn.cpp */; };
@@ -333,12 +418,10 @@
 		F897ECBF266EFF93005EE8F7 /* apple80211_var.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC425021DEC000F77FF /* apple80211_var.h */; };
 		F897ECC0266EFF93005EE8F7 /* AirportItlwmInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F8CA44A225091AF60036119A /* AirportItlwmInterface.hpp */; };
 		F897ECC1266EFF93005EE8F7 /* IO80211Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA38252D834500520FD4 /* IO80211Interface.h */; };
-		F897ECC2266EFF93005EE8F7 /* (null) in Headers */ = {isa = PBXBuildFile; };
 		F897ECC3266EFF93005EE8F7 /* IO80211SkywalkInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA37252D834500520FD4 /* IO80211SkywalkInterface.h */; };
 		F897ECC4266EFF93005EE8F7 /* AirportItlwm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BBB25021C9C000F77FF /* AirportItlwm.hpp */; };
 		F897ECC5266EFF93005EE8F7 /* IO80211VirtualInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA34252D834500520FD4 /* IO80211VirtualInterface.h */; };
 		F897ECC6266EFF93005EE8F7 /* IO80211Controller.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F7EA35252D834500520FD4 /* IO80211Controller.h */; };
-		F897ECC7266EFF93005EE8F7 /* (null) in Headers */ = {isa = PBXBuildFile; };
 		F897ECC8266EFF93005EE8F7 /* ieee80211_ra.h in Headers */ = {isa = PBXBuildFile; fileRef = F8C594D225FD935B0007D19C /* ieee80211_ra.h */; };
 		F897ECC9266EFF93005EE8F7 /* apple80211_wps.h in Headers */ = {isa = PBXBuildFile; fileRef = F89B6BC325021DEC000F77FF /* apple80211_wps.h */; };
 		F897ECCB266EFF93005EE8F7 /* _mbuf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8D257732495A33500872E4F /* _mbuf.cpp */; };
@@ -380,7 +463,6 @@
 		F897ECEF266EFF93005EE8F7 /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07DD23FCBC6C009FBA6C /* cmac.c */; };
 		F897ECF0266EFF93005EE8F7 /* ecb_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E423FCBC6C009FBA6C /* ecb_enc.c */; };
 		F897ECF1266EFF93005EE8F7 /* chachapoly.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07E923FCBC6C009FBA6C /* chachapoly.c */; };
-		F897ECF2266EFF93005EE8F7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		F897ECF3266EFF93005EE8F7 /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EA23FCBC6C009FBA6C /* md5.c */; };
 		F897ECF4266EFF93005EE8F7 /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EB23FCBC6C009FBA6C /* arc4.c */; };
 		F897ECF5266EFF93005EE8F7 /* blf.c in Sources */ = {isa = PBXBuildFile; fileRef = 024A07EC23FCBC6C009FBA6C /* blf.c */; };
@@ -592,6 +674,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1776943F26578D930019558D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5066D63825287F7900EE6F38;
+			remoteInfo = fw_gen;
+		};
 		5066D63D252880A700EE6F38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 024A07A323FCBC3C009FBA6C /* Project object */;
@@ -703,6 +792,7 @@
 		024A08D123FCF395009FBA6C /* led.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = led.cpp; sourceTree = "<group>"; };
 		024A08D323FCF3E6009FBA6C /* power.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = power.cpp; sourceTree = "<group>"; };
 		024A08D523FCF4D7009FBA6C /* scan.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = scan.cpp; sourceTree = "<group>"; };
+		1776949F26578D930019558D /* AirportItlwm.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirportItlwm.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		17FD7F0C255E4A0900611406 /* if_iwnvar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = if_iwnvar.h; sourceTree = "<group>"; };
 		17FD7F0D255E4AB000611406 /* if_iwnreg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = if_iwnreg.h; sourceTree = "<group>"; };
 		17FD7F0E255E4AC800611406 /* ItlIwn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ItlIwn.cpp; sourceTree = "<group>"; };
@@ -860,6 +950,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1776949926578D930019558D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1776949A26578D930019558D /* libkmod.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		35CBE6B5251CB89700435CBC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -927,6 +1025,7 @@
 				35CBE724251CB8BF00435CBC /* AirportItlwm.kext */,
 				35CBE78F251CB8CA00435CBC /* AirportItlwm.kext */,
 				F897ED18266EFF93005EE8F7 /* AirportItlwm.kext */,
+				1776949F26578D930019558D /* AirportItlwm.kext */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1344,6 +1443,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1776944026578D930019558D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1776944126578D930019558D /* debug.h in Headers */,
+				1776944226578D930019558D /* IOSkywalkEthernetInterface.h in Headers */,
+				1776944326578D930019558D /* apple80211_ioctl.h in Headers */,
+				1776944426578D930019558D /* IO80211P2PInterface.h in Headers */,
+				1776944526578D930019558D /* IO80211WorkLoop.h in Headers */,
+				1776944626578D930019558D /* apple80211_var.h in Headers */,
+				1776944726578D930019558D /* AirportItlwmInterface.hpp in Headers */,
+				1776944826578D930019558D /* IO80211Interface.h in Headers */,
+				1776944A26578D930019558D /* IO80211SkywalkInterface.h in Headers */,
+				1776944B26578D930019558D /* AirportItlwm.hpp in Headers */,
+				1776944C26578D930019558D /* IO80211VirtualInterface.h in Headers */,
+				1776944D26578D930019558D /* IO80211Controller.h in Headers */,
+				1776944F26578D930019558D /* ieee80211_ra.h in Headers */,
+				1776945026578D930019558D /* apple80211_wps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		35CBE658251CB89700435CBC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1419,12 +1539,10 @@
 				F897ECBF266EFF93005EE8F7 /* apple80211_var.h in Headers */,
 				F897ECC0266EFF93005EE8F7 /* AirportItlwmInterface.hpp in Headers */,
 				F897ECC1266EFF93005EE8F7 /* IO80211Interface.h in Headers */,
-				F897ECC2266EFF93005EE8F7 /* (null) in Headers */,
 				F897ECC3266EFF93005EE8F7 /* IO80211SkywalkInterface.h in Headers */,
 				F897ECC4266EFF93005EE8F7 /* AirportItlwm.hpp in Headers */,
 				F897ECC5266EFF93005EE8F7 /* IO80211VirtualInterface.h in Headers */,
 				F897ECC6266EFF93005EE8F7 /* IO80211Controller.h in Headers */,
-				F897ECC7266EFF93005EE8F7 /* (null) in Headers */,
 				F897ECC8266EFF93005EE8F7 /* ieee80211_ra.h in Headers */,
 				F897ECC9266EFF93005EE8F7 /* apple80211_wps.h in Headers */,
 			);
@@ -1471,6 +1589,25 @@
 			name = itlwm;
 			productName = itlwm;
 			productReference = 024A07AC23FCBC3C009FBA6C /* itlwm.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		1776943D26578D930019558D /* AirportItlwm-Sierra */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1776949C26578D930019558D /* Build configuration list for PBXNativeTarget "AirportItlwm-Sierra" */;
+			buildPhases = (
+				1776944026578D930019558D /* Headers */,
+				1776945126578D930019558D /* Sources */,
+				1776949926578D930019558D /* Frameworks */,
+				1776949B26578D930019558D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1776943E26578D930019558D /* PBXTargetDependency */,
+			);
+			name = "AirportItlwm-Sierra";
+			productName = AirportItlwm;
+			productReference = 1776949F26578D930019558D /* AirportItlwm.kext */;
 			productType = "com.apple.product-type.kernel-extension";
 		};
 		35CBE655251CB89700435CBC /* AirportItlwm-Big Sur */ = {
@@ -1581,6 +1718,9 @@
 						CreatedOnToolsVersion = 11.1;
 						ProvisioningStyle = Manual;
 					};
+					1776943D26578D930019558D = {
+						ProvisioningStyle = Manual;
+					};
 					35CBE655251CB89700435CBC = {
 						ProvisioningStyle = Manual;
 					};
@@ -1617,6 +1757,7 @@
 			projectRoot = "";
 			targets = (
 				024A07AB23FCBC3C009FBA6C /* itlwm */,
+				1776943D26578D930019558D /* AirportItlwm-Sierra */,
 				35CBE72A251CB8CA00435CBC /* AirportItlwm-High Sierra */,
 				35CBE6BF251CB8BF00435CBC /* AirportItlwm-Mojave */,
 				F89B6BB825021C9C000F77FF /* AirportItlwm-Catalina */,
@@ -1633,6 +1774,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				F883EC20266F43F200EA018C /* AirportItlwm-Monterey-Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1776949B26578D930019558D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1769,6 +1917,83 @@
 				024A08C423FCDC14009FBA6C /* rx.cpp in Sources */,
 				F8C2EC5C2408031A007A9422 /* ieee80211_crypto_tkip.c in Sources */,
 				024A085123FCBC6C009FBA6C /* blf.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1776945126578D930019558D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1776945226578D930019558D /* _mbuf.cpp in Sources */,
+				1776945326578D930019558D /* ieee80211_ra.c in Sources */,
+				1776945426578D930019558D /* _task.cpp in Sources */,
+				1776945526578D930019558D /* FwBinary.cpp in Sources */,
+				1776945626578D930019558D /* IOTaskQueue.cpp in Sources */,
+				1776945726578D930019558D /* ieee80211_proto.c in Sources */,
+				1776945826578D930019558D /* AirportItlwmInterface.cpp in Sources */,
+				1776945926578D930019558D /* _string.c in Sources */,
+				1776945A26578D930019558D /* ieee80211_ioctl.c in Sources */,
+				1776945B26578D930019558D /* ieee80211.c in Sources */,
+				1776945C26578D930019558D /* ieee80211_rssadapt.c in Sources */,
+				1776945D26578D930019558D /* ieee80211_input.c in Sources */,
+				1776945E26578D930019558D /* timeout.c in Sources */,
+				1776945F26578D930019558D /* ieee80211_mira.c in Sources */,
+				1776946026578D930019558D /* ieee80211_crypto_bip.c in Sources */,
+				1776946126578D930019558D /* ieee80211_crypto_tkip.c in Sources */,
+				1776946226578D930019558D /* ieee80211_crypto_ccmp.c in Sources */,
+				1776946326578D930019558D /* ieee80211_crypto_wep.c in Sources */,
+				1776946426578D930019558D /* ieee80211_pae_input.c in Sources */,
+				1776946526578D930019558D /* ieee80211_amrr.c in Sources */,
+				1776946626578D930019558D /* ieee80211_output.c in Sources */,
+				1776946726578D930019558D /* ieee80211_crypto.c in Sources */,
+				1776946826578D930019558D /* CTimeout.cpp in Sources */,
+				1776946926578D930019558D /* ieee80211_regdomain.c in Sources */,
+				1776946A26578D930019558D /* ieee80211_node.c in Sources */,
+				1776946B26578D930019558D /* ieee80211_pae_output.c in Sources */,
+				1776946C26578D930019558D /* sha1-pbkdf2.c in Sources */,
+				1776946D26578D930019558D /* aes.c in Sources */,
+				1776946E26578D930019558D /* hmac.c in Sources */,
+				1776946F26578D930019558D /* sha2.c in Sources */,
+				1776947026578D930019558D /* rijndael.c in Sources */,
+				1776947126578D930019558D /* ecb3_enc.c in Sources */,
+				1776947226578D930019558D /* set_key.c in Sources */,
+				1776947326578D930019558D /* cast.c in Sources */,
+				1776947426578D930019558D /* michael.c in Sources */,
+				1776947526578D930019558D /* sha1.c in Sources */,
+				1776947626578D930019558D /* cmac.c in Sources */,
+				1776947726578D930019558D /* ecb_enc.c in Sources */,
+				1776947826578D930019558D /* chachapoly.c in Sources */,
+				1776947A26578D930019558D /* md5.c in Sources */,
+				1776947B26578D930019558D /* arc4.c in Sources */,
+				1776947C26578D930019558D /* blf.c in Sources */,
+				1776947D26578D930019558D /* poly1305.c in Sources */,
+				1776947E26578D930019558D /* key_wrap.c in Sources */,
+				1776947F26578D930019558D /* gmac.c in Sources */,
+				1776948026578D930019558D /* rmd160.c in Sources */,
+				1776948126578D930019558D /* idgen.c in Sources */,
+				1776948226578D930019558D /* compat.cpp in Sources */,
+				1776948326578D930019558D /* zutil.c in Sources */,
+				1776948426578D930019558D /* ItlHalService.cpp in Sources */,
+				1776948526578D930019558D /* ItlIwx.cpp in Sources */,
+				1776948626578D930019558D /* utils.cpp in Sources */,
+				1776948726578D930019558D /* fw.cpp in Sources */,
+				1776948826578D930019558D /* io.cpp in Sources */,
+				1776948926578D930019558D /* rx.cpp in Sources */,
+				1776948A26578D930019558D /* tx.cpp in Sources */,
+				1776948B26578D930019558D /* hw.cpp in Sources */,
+				1776948C26578D930019558D /* ItlIwn.cpp in Sources */,
+				1776948D26578D930019558D /* phy.cpp in Sources */,
+				1776948E26578D930019558D /* mac80211.cpp in Sources */,
+				1776948F26578D930019558D /* nvm.cpp in Sources */,
+				1776949026578D930019558D /* ctxt.cpp in Sources */,
+				1776949126578D930019558D /* led.cpp in Sources */,
+				1776949226578D930019558D /* power.cpp in Sources */,
+				1776949326578D930019558D /* scan.cpp in Sources */,
+				1776949426578D930019558D /* ItlIwm.cpp in Sources */,
+				1776949526578D930019558D /* AirportSTAIOCTL.cpp in Sources */,
+				1776949626578D930019558D /* AirportItlwm.cpp in Sources */,
+				1776949726578D930019558D /* AirportVirtualIOCTL.cpp in Sources */,
+				1776949826578D930019558D /* AirportAWDL.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2046,7 +2271,6 @@
 				F897ECEF266EFF93005EE8F7 /* cmac.c in Sources */,
 				F897ECF0266EFF93005EE8F7 /* ecb_enc.c in Sources */,
 				F897ECF1266EFF93005EE8F7 /* chachapoly.c in Sources */,
-				F897ECF2266EFF93005EE8F7 /* (null) in Sources */,
 				F897ECF3266EFF93005EE8F7 /* md5.c in Sources */,
 				F897ECF4266EFF93005EE8F7 /* arc4.c in Sources */,
 				F897ECF5266EFF93005EE8F7 /* blf.c in Sources */,
@@ -2161,6 +2385,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1776943E26578D930019558D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5066D63825287F7900EE6F38 /* fw_gen */;
+			targetProxy = 1776943F26578D930019558D /* PBXContainerItemProxy */;
+		};
 		5066D63E252880A700EE6F38 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5066D63825287F7900EE6F38 /* fw_gen */;
@@ -2379,6 +2608,66 @@
 				MODULE_NAME = com.zxystd.itlwm;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.itlwm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		1776949D26578D930019558D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/$(CONFIGURATION)/Sierra";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = itlwm/PrivateSPI.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					USE_APPLE_SUPPLICANT,
+					AIRPORT,
+					"__IO80211_TARGET=__MAC_10_12",
+					__PRIVATE_SPI__,
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
+				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		1776949E26578D930019558D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)/$(CONFIGURATION)/Sierra";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = itlwm/PrivateSPI.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"__IO80211_TARGET=__MAC_10_12",
+					USE_APPLE_SUPPLICANT,
+					AIRPORT,
+					__PRIVATE_SPI__,
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = AirportItlwm/Info.plist;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/itl80211",
+					"$(inherited)",
+					"$(PROJECT_DIR)/itl80211/openbsd",
+					"$(PROJECT_DIR)/itl80211/linux",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MODULE_NAME = com.zxystd.AirportItlwm;
+				PRODUCT_BUNDLE_IDENTIFIER = com.zxystd.AirportItlwm;
+				PRODUCT_NAME = AirportItlwm;
 				SYSTEM_HEADER_SEARCH_PATHS = "itl80211/openbsd itl80211 include";
 				WRAPPER_EXTENSION = kext;
 			};
@@ -2723,6 +3012,15 @@
 			buildConfigurations = (
 				024A07B723FCBC3C009FBA6C /* Debug */,
 				024A07B823FCBC3C009FBA6C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1776949C26578D930019558D /* Build configuration list for PBXNativeTarget "AirportItlwm-Sierra" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1776949D26578D930019558D /* Debug */,
+				1776949E26578D930019558D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm (all).xcscheme
+++ b/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm (all).xcscheme
@@ -76,6 +76,20 @@
                ReferencedContainer = "container:itlwm.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1776943D26578D930019558D"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-Sierra"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm (all).xcscheme
+++ b/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm (all).xcscheme
@@ -90,6 +90,34 @@
                ReferencedContainer = "container:itlwm.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "17EA50AC267F1712005FA1FB"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-El Captain"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "17EA510D267F205F005FA1FB"
+               BuildableName = "AirportItlwm.kext"
+               BlueprintName = "AirportItlwm-Yosemite"
+               ReferencedContainer = "container:itlwm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm-legacy.xcscheme
+++ b/itlwm.xcodeproj/xcshareddata/xcschemes/AirportItlwm-legacy.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "35CBE655251CB89700435CBC"
+               BlueprintIdentifier = "1776943D26578D930019558D"
                BuildableName = "AirportItlwm.kext"
-               BlueprintName = "AirportItlwm-Big Sur"
+               BlueprintName = "AirportItlwm-Sierra"
                ReferencedContainer = "container:itlwm.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,9 +28,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F89B6BB825021C9C000F77FF"
+               BlueprintIdentifier = "17EA50AC267F1712005FA1FB"
                BuildableName = "AirportItlwm.kext"
-               BlueprintName = "AirportItlwm-Catalina"
+               BlueprintName = "AirportItlwm-El Captain"
                ReferencedContainer = "container:itlwm.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -42,37 +42,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "35CBE72A251CB8CA00435CBC"
+               BlueprintIdentifier = "17EA510D267F205F005FA1FB"
                BuildableName = "AirportItlwm.kext"
-               BlueprintName = "AirportItlwm-High Sierra"
-               ReferencedContainer = "container:itlwm.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "35CBE6BF251CB8BF00435CBC"
-               BuildableName = "AirportItlwm.kext"
-               BlueprintName = "AirportItlwm-Mojave"
-               ReferencedContainer = "container:itlwm.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F897ECB6266EFF93005EE8F7"
-               BuildableName = "AirportItlwm.kext"
-               BlueprintName = "AirportItlwm-Monterey"
+               BlueprintName = "AirportItlwm-Yosemite"
                ReferencedContainer = "container:itlwm.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -103,15 +75,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "35CBE655251CB89700435CBC"
-            BuildableName = "AirportItlwm.kext"
-            BlueprintName = "AirportItlwm-Big Sur"
-            ReferencedContainer = "container:itlwm.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This pull request adds AirportItlwm support on the following OS versions
- macOS Sierra 10.12 (Tested 10.12.6)
- OS X El Captain 10.11 (Tested 10.11.6)
- OS X Yosemite 10.10 (Tested 10.10.5)

The main change is to add #ifdef in the airport headers on the virtual methods.

I had to change a bit on the createWorkLoop(), otherwise a kernel will panic on IO80211Controller::copyOut() method on 10.11 and 10.10. The IO80211Controller::copyOut() in the older version directly reference to the private workloop object created by the IO80211Controller::createWorkLoop() instead of calling the virtual method getWorkLoop(). The fix is to call the createWorkLoop() in the base and reuse the workloop object

Other changes are strait forward.

I haven't look into use bootloaders to inject the kext because its dependency on IO80211Family.kext. It works well for me if I copy the kext to /Library/Extensions and update the kernel cache. On 10.11 and above, SIP need to be disabled to load unsigned kext. On 10.10, the kext-dev-mode=1 boot args is also needed to load unsigned kext.