### PR TITLE
Fix WPA2PSK SHA256 support in AirportItlwm

### DIFF
--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -184,7 +184,7 @@ void AirportItlwm::associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct 
         wpa.i_protos = IEEE80211_WPA_PROTO_WPA1 | IEEE80211_WPA_PROTO_WPA2;
     }
     
-    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA_PSK | APPLE80211_AUTHTYPE_WPA2_PSK)) {
+    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA_PSK | APPLE80211_AUTHTYPE_WPA2_PSK | APPLE80211_AUTHTYPE_SHA256_PSK)) {
         XYLog("%s %d\n", __FUNCTION__, __LINE__);
         wpa.i_akms |= IEEE80211_WPA_AKM_PSK | IEEE80211_WPA_AKM_SHA256_PSK;
         wpa.i_enabled = 1;
@@ -192,7 +192,7 @@ void AirportItlwm::associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct 
         ic->ic_flags |= IEEE80211_F_PSK;
         ieee80211_ioctl_setwpaparms(ic, &wpa);
     }
-    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA | APPLE80211_AUTHTYPE_WPA2)) {
+    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA | APPLE80211_AUTHTYPE_WPA2 | APPLE80211_AUTHTYPE_SHA256_8021X)) {
         XYLog("%s %d\n", __FUNCTION__, __LINE__);
         wpa.i_akms |= IEEE80211_WPA_AKM_8021X | IEEE80211_WPA_AKM_SHA256_8021X;	
         wpa.i_enabled = 1;


### PR DESCRIPTION
I recently enabled optional 802.11w on my openwrt router, and AirportItlwm is unable to reconnect to the router.

I found when enabling 802.11w, WPA2PSK SHA256 is also enabled. Apple prefer to set auth_upper=1024 ( APPLE80211_AUTHTYPE_SHA256_PSK) in this case. The current code doesn't translate this flag APPLE80211_AUTHTYPE_SHA256_PSK to proper flags in the net80211 stack, causing association to timeout and password prompt.