### PR TITLE
Support 11w protected management frames

### DIFF
--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -349,6 +349,14 @@ void AirportItlwm::setIGTK(const u_int8_t *igtk, size_t key_len, u_int8_t kid, u
                 XYLog("setting IGTK successfully\n");
             }
         }
+        
+        /* use MFP if we both support it */
+        if (ic->ic_caps & IEEE80211_C_MFP) {
+            ni->ni_flags |= IEEE80211_NODE_MFP;
+            ni->ni_flags |= IEEE80211_NODE_TXMGMTPROT;
+            ni->ni_flags |= IEEE80211_NODE_RXMGMTPROT;
+            ic->ic_igtk_kid = kid;
+        }
     }
 }
 

--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -313,6 +313,44 @@ void AirportItlwm::setGTK(const u_int8_t *gtk, size_t key_len, u_int8_t kid, u_i
     }
 }
 
+void AirportItlwm::setIGTK(const u_int8_t *igtk, size_t key_len, u_int8_t kid, u_int8_t *rsc) {
+    struct ieee80211com *ic = fHalService->get80211Controller();
+    struct ieee80211_node    * ni = ic->ic_bss;
+    struct ieee80211_key *k;
+    int keylen;
+    
+    if (igtk != NULL) {
+        /* check that the IGTK KDE is valid */
+        keylen = ieee80211_cipher_keylen(ni->ni_rsngroupmgmtcipher);
+        if (key_len != keylen) {
+            XYLog("IGTK length mismatch. expected %d, got %zu\n", keylen, key_len);
+            return;
+        }
+        if (kid != 4 && kid != 5) {
+            XYLog("unsupported IGTK id %u\n", kid);
+            return;
+        }
+        /* map GTK to 802.11 key */
+        k = &ic->ic_nw_keys[kid];
+        if (k->k_cipher == IEEE80211_CIPHER_NONE || k->k_len != keylen || memcmp(k->k_key, igtk, keylen) != 0) {
+            memset(k, 0, sizeof(*k));
+            k->k_id = kid;    /* either 4 or 5 */
+            k->k_cipher = ni->ni_rsngroupmgmtcipher;
+            k->k_flags = IEEE80211_KEY_IGTK;
+            k->k_mgmt_rsc = LE_READ_6(rsc);    /* IPN */
+            k->k_len = keylen;
+            memcpy(k->k_key, igtk, k->k_len);
+            /* install the IGTK */
+            if ((*ic->ic_set_key)(ic, ni, k) != 0) {
+                XYLog("setting IGTK failed\n");
+                return;
+            }
+            else {
+                XYLog("setting IGTK successfully\n");
+            }
+        }
+    }
+}
 
 bool AirportItlwm::
 createMediumTables(const IONetworkMedium **primary)

--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -351,7 +351,8 @@ void AirportItlwm::setIGTK(const u_int8_t *igtk, size_t key_len, u_int8_t kid, u
         }
         
         /* use MFP if we both support it */
-        if (ic->ic_caps & IEEE80211_C_MFP) {
+        if ((ic->ic_caps & IEEE80211_C_MFP) &&
+            (ni->ni_rsncaps & IEEE80211_RSNCAP_MFPC)) {
             ni->ni_flags |= IEEE80211_NODE_MFP;
             ni->ni_flags |= IEEE80211_NODE_TXMGMTPROT;
             ni->ni_flags |= IEEE80211_NODE_RXMGMTPROT;

--- a/AirportItlwm/AirportItlwm.cpp
+++ b/AirportItlwm/AirportItlwm.cpp
@@ -185,7 +185,7 @@ void AirportItlwm::associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct 
         wpa.i_protos = IEEE80211_WPA_PROTO_WPA1 | IEEE80211_WPA_PROTO_WPA2;
     }
     
-    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA_PSK | APPLE80211_AUTHTYPE_WPA2_PSK)) {
+    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA_PSK | APPLE80211_AUTHTYPE_WPA2_PSK | APPLE80211_AUTHTYPE_SHA256_PSK)) {
         XYLog("%s %d\n", __FUNCTION__, __LINE__);
         wpa.i_akms |= IEEE80211_WPA_AKM_PSK | IEEE80211_WPA_AKM_SHA256_PSK;
         wpa.i_enabled = 1;
@@ -193,7 +193,7 @@ void AirportItlwm::associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct 
         ic->ic_flags |= IEEE80211_F_PSK;
         ieee80211_ioctl_setwpaparms(ic, &wpa);
     }
-    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA | APPLE80211_AUTHTYPE_WPA2)) {
+    if (authtype_upper & (APPLE80211_AUTHTYPE_WPA | APPLE80211_AUTHTYPE_WPA2 | APPLE80211_AUTHTYPE_SHA256_8021X)) {
         XYLog("%s %d\n", __FUNCTION__, __LINE__);
         wpa.i_akms |= IEEE80211_WPA_AKM_8021X | IEEE80211_WPA_AKM_SHA256_8021X;	
         wpa.i_enabled = 1;

--- a/AirportItlwm/AirportItlwm.hpp
+++ b/AirportItlwm/AirportItlwm.hpp
@@ -97,6 +97,7 @@ public:
     void associateSSID(uint8_t *ssid, uint32_t ssid_len, const struct ether_addr &bssid, uint32_t authtype_lower, uint32_t authtype_upper, uint8_t *key, uint32_t key_len, int key_index);
     void setPTK(const u_int8_t *key, size_t key_len);
     void setGTK(const u_int8_t *key, size_t key_len, u_int8_t kid, u_int8_t *rsc);
+    void setIGTK(const u_int8_t *key, size_t key_len, u_int8_t kid, u_int8_t *rsc);
     void watchdogAction(IOTimerEventSource *timer);
     bool initPCIPowerManagment(IOPCIDevice *provider);
     static IOReturn tsleepHandler(OSObject* owner, void* arg0 = 0, void* arg1 = 0, void* arg2 = 0, void* arg3 = 0);

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -284,6 +284,10 @@ setCIPHER_KEY(OSObject *object, struct apple80211_key *key)
                     setGTK(key->key, key->key_len, key->key_index, key->key_rsc);
                     getNetworkInterface()->postMessage(APPLE80211_M_RSN_HANDSHAKE_DONE);
                     break;
+                case 64: // IGTK
+                    setIGTK(key->key, key->key_len, key->key_index, key->key_rsc);
+                    getNetworkInterface()->postMessage(APPLE80211_M_RSN_HANDSHAKE_DONE);
+                    break;
             }
             break;
         case APPLE80211_CIPHER_PMK:

--- a/itl80211/openbsd/net80211/ieee80211_crypto.c
+++ b/itl80211/openbsd/net80211/ieee80211_crypto.c
@@ -312,10 +312,12 @@ ieee80211_decrypt(struct ieee80211com *ic, mbuf_t m0,
 	/* find key for decryption */
     k = ieee80211_get_rxkey(ic, m0, ni);
     if (k == NULL || (k->k_flags & IEEE80211_KEY_SWCRYPTO) == 0) {
+        XYLog("%s: BUG! key unset for sw crypto. k_id: %d k_cipher: %d k_flags: %d\n",
+              __FUNCTION__, k ? k->k_id : -1, k ? k->k_cipher : -1, k ? k->k_flags : -1);
         mbuf_freem(m0);
         return NULL;
     }
-
+    
     switch (k->k_cipher) {
     case IEEE80211_CIPHER_WEP40:
     case IEEE80211_CIPHER_WEP104:

--- a/itl80211/openbsd/net80211/ieee80211_crypto.c
+++ b/itl80211/openbsd/net80211/ieee80211_crypto.c
@@ -317,7 +317,7 @@ ieee80211_decrypt(struct ieee80211com *ic, mbuf_t m0,
         mbuf_freem(m0);
         return NULL;
     }
-    
+
     switch (k->k_cipher) {
     case IEEE80211_CIPHER_WEP40:
     case IEEE80211_CIPHER_WEP104:
@@ -386,7 +386,7 @@ ieee80211_kdf(const u_int8_t *key, size_t key_len, const u_int8_t *label,
         HMAC_SHA256_Init(&ctx, key, key_len);
         iter = htole16(i);
         HMAC_SHA256_Update(&ctx, (u_int8_t *)&iter, sizeof iter);
-        HMAC_SHA256_Update(&ctx, label, label_len);
+        HMAC_SHA256_Update(&ctx, label, strlen((const char*)label));
         HMAC_SHA256_Update(&ctx, context, context_len);
         HMAC_SHA256_Update(&ctx, (u_int8_t *)&length, sizeof length);
         if (len < SHA256_DIGEST_LENGTH) {
@@ -426,7 +426,7 @@ ieee80211_derive_ptk(enum ieee80211_akm akm, const u_int8_t *pmk,
 
     kdf = ieee80211_is_sha256_akm(akm) ? ieee80211_kdf : ieee80211_prf;
     (*kdf)(pmk, IEEE80211_PMK_LEN, (const u_int8_t *)"Pairwise key expansion", 23,
-        buf, sizeof buf, (u_int8_t *)ptk, sizeof(*ptk));
+           buf, sizeof buf, (u_int8_t *)ptk, kdf ? 48 : sizeof(*ptk));
 }
 
 static void

--- a/itl80211/openbsd/net80211/ieee80211_output.c
+++ b/itl80211/openbsd/net80211/ieee80211_output.c
@@ -224,8 +224,10 @@ ieee80211_mgmt_output(struct _ifnet *ifp, struct ieee80211_node *ni,
              * XXX could use an mbuf flag..
              */
             if (IEEE80211_IS_MULTICAST(wh->i_addr1) ||
-                (ni->ni_flags & IEEE80211_NODE_TXMGMTPROT))
+                (ni->ni_flags & IEEE80211_NODE_TXMGMTPROT)) {
+                XYLog("%s %d type=%d going to protect.\n", __FUNCTION__, __LINE__, type);
                 wh->i_fc[1] |= IEEE80211_FC1_PROTECTED;
+            }
         }
 
         if (ifp->if_flags & IFF_DEBUG) {

--- a/itl80211/openbsd/net80211/ieee80211_pae_input.c
+++ b/itl80211/openbsd/net80211/ieee80211_pae_input.c
@@ -673,6 +673,9 @@ ieee80211_recv_4way_msg3(struct ieee80211com *ic,
                     reason = IEEE80211_REASON_AUTH_LEAVE;
                     goto deauth;
             }
+            ni->ni_flags |= IEEE80211_NODE_TXMGMTPROT;
+            ni->ni_flags |= IEEE80211_NODE_RXMGMTPROT;
+            ic->ic_igtk_kid = kid;
         }
     }
     if (info & EAPOL_KEY_INSTALL)

--- a/itl80211/openbsd/net80211/ieee80211_pae_input.c
+++ b/itl80211/openbsd/net80211/ieee80211_pae_input.c
@@ -965,6 +965,9 @@ ieee80211_recv_rsn_group_msg1(struct ieee80211com *ic,
                     reason = IEEE80211_REASON_AUTH_LEAVE;
                     goto deauth;
             }
+            ni->ni_flags |= IEEE80211_NODE_TXMGMTPROT;
+            ni->ni_flags |= IEEE80211_NODE_RXMGMTPROT;
+            ic->ic_igtk_kid = kid;
         }
     }
     if (info & EAPOL_KEY_SECURE) {

--- a/itlwm/hal_iwm/mac80211.cpp
+++ b/itlwm/hal_iwm/mac80211.cpp
@@ -4852,7 +4852,8 @@ iwm_attach(struct iwm_softc *sc, struct pci_attach_args *pa)
     IEEE80211_C_SCANALLBAND |    /* device scans all bands at once */
     IEEE80211_C_MONITOR |    /* monitor mode supported */
     IEEE80211_C_SHSLOT |    /* short slot time supported */
-    IEEE80211_C_SHPREAMBLE;    /* short preamble supported */
+    IEEE80211_C_SHPREAMBLE |    /* short preamble supported */
+    IEEE80211_C_MFP;    /* management frame protection 11w supported */
     
     ic->ic_htcaps = IEEE80211_HTCAP_SGI20;
     ic->ic_htcaps |=

--- a/itlwm/hal_iwm/mac80211.cpp
+++ b/itlwm/hal_iwm/mac80211.cpp
@@ -1736,7 +1736,6 @@ iwm_tx(struct iwm_softc *sc, mbuf_t m, struct ieee80211_node *ni, int ac)
         if ((k->k_flags & IEEE80211_KEY_GROUP) ||
             (k->k_flags & IEEE80211_KEY_IGTK) ||
             (k->k_cipher != IEEE80211_CIPHER_CCMP)) {
-            XYLog("%s %d k_flags=%d k_cipher=%d\n", __FUNCTION__, __LINE__, k->k_flags, k->k_cipher);
             if ((m = ieee80211_encrypt(ic, m, k)) == NULL)
                 return ENOBUFS;
             /* 802.11 header may have moved. */
@@ -2610,7 +2609,7 @@ iwm_set_key(struct ieee80211com *ic, struct ieee80211_node *ni,
         /* Fallback to software crypto for other ciphers. */
         return (ieee80211_set_key(ic, ni, k));
     }
-
+    
     if (!isset(sc->sc_ucode_api, IWM_UCODE_TLV_API_TKIP_MIC_KEYS))
         return that->iwm_set_key_v1(ic, ni, k);
     

--- a/itlwm/hal_iwm/mac80211.cpp
+++ b/itlwm/hal_iwm/mac80211.cpp
@@ -1734,7 +1734,9 @@ iwm_tx(struct iwm_softc *sc, mbuf_t m, struct ieee80211_node *ni, int ac)
     if (wh->i_fc[1] & IEEE80211_FC1_PROTECTED) {
         k = ieee80211_get_txkey(ic, wh, ni);
         if ((k->k_flags & IEEE80211_KEY_GROUP) ||
+            (k->k_flags & IEEE80211_KEY_IGTK) ||
             (k->k_cipher != IEEE80211_CIPHER_CCMP)) {
+            XYLog("%s %d k_flags=%d k_cipher=%d\n", __FUNCTION__, __LINE__, k->k_flags, k->k_cipher);
             if ((m = ieee80211_encrypt(ic, m, k)) == NULL)
                 return ENOBUFS;
             /* 802.11 header may have moved. */
@@ -2603,11 +2605,12 @@ iwm_set_key(struct ieee80211com *ic, struct ieee80211_node *ni,
     ItlIwm *that = container_of(sc, ItlIwm, com);
     
     if ((k->k_flags & IEEE80211_KEY_GROUP) ||
+        (k->k_flags & IEEE80211_KEY_IGTK) ||
         k->k_cipher != IEEE80211_CIPHER_CCMP)  {
         /* Fallback to software crypto for other ciphers. */
         return (ieee80211_set_key(ic, ni, k));
     }
-    
+
     if (!isset(sc->sc_ucode_api, IWM_UCODE_TLV_API_TKIP_MIC_KEYS))
         return that->iwm_set_key_v1(ic, ni, k);
     
@@ -2659,9 +2662,10 @@ iwm_delete_key(struct ieee80211com *ic, struct ieee80211_node *ni,
     ItlIwm *that = container_of(sc, ItlIwm, com);
 
    if ((k->k_flags & IEEE80211_KEY_GROUP) ||
+       (k->k_flags & IEEE80211_KEY_IGTK) ||
        (k->k_cipher != IEEE80211_CIPHER_CCMP)) {
        /* Fallback to software crypto for other ciphers. */
-                ieee80211_delete_key(ic, ni, k);
+       ieee80211_delete_key(ic, ni, k);
        return;
    }
 

--- a/itlwm/hal_iwn/ItlIwn.cpp
+++ b/itlwm/hal_iwn/ItlIwn.cpp
@@ -495,7 +495,8 @@ iwn_attach(struct iwn_softc *sc, struct pci_attach_args *pa)
         IEEE80211_C_MONITOR |    /* monitor mode supported */
         IEEE80211_C_SHSLOT |    /* short slot time supported */
         IEEE80211_C_SHPREAMBLE |    /* short preamble supported */
-        IEEE80211_C_PMGT;        /* power saving supported */
+        IEEE80211_C_PMGT |        /* power saving supported */
+        IEEE80211_C_MFP;    /* management frame protection 11w supported */
 
     /* No optional HT features supported for now, */
     ic->ic_htcaps = 0;
@@ -3517,7 +3518,9 @@ iwn_tx(struct iwn_softc *sc, mbuf_t m, struct ieee80211_node *ni)
     if (wh->i_fc[1] & IEEE80211_FC1_PROTECTED) {
         /* Retrieve key for TX. */
         k = ieee80211_get_txkey(ic, wh, ni);
-        if (k->k_cipher != IEEE80211_CIPHER_CCMP) {
+        if ((k->k_flags & IEEE80211_KEY_GROUP) ||
+            (k->k_flags & IEEE80211_KEY_IGTK) ||
+            (k->k_cipher != IEEE80211_CIPHER_CCMP)) {
             /* Do software encryption. */
             if ((m = ieee80211_encrypt(ic, m, k)) == NULL)
                 return ENOBUFS;
@@ -3525,9 +3528,11 @@ iwn_tx(struct iwn_softc *sc, mbuf_t m, struct ieee80211_node *ni)
             wh = mtod(m, struct ieee80211_frame *);
             //    totlen = m->m_pkthdr.len;
             totlen = mbuf_pkthdr_len(m);
-
-        } else    /* HW appends CCMP MIC. */
+            k = NULL; /* skip hardware crypto below */
+        } else {
+            /* HW appends CCMP MIC. */
             totlen += IEEE80211_CCMP_HDRLEN;
+        }
     }
 
     data->totlen = totlen;
@@ -5855,6 +5860,7 @@ iwn_set_key(struct ieee80211com *ic, struct ieee80211_node *ni,
     uint16_t kflags;
 
     if ((k->k_flags & IEEE80211_KEY_GROUP) ||
+        (k->k_flags & IEEE80211_KEY_IGTK) ||
         k->k_cipher != IEEE80211_CIPHER_CCMP)
         return ieee80211_set_key(ic, ni, k);
 
@@ -5884,6 +5890,7 @@ iwn_delete_key(struct ieee80211com *ic, struct ieee80211_node *ni,
     struct iwn_node_info node;
 
     if ((k->k_flags & IEEE80211_KEY_GROUP) ||
+        (k->k_flags & IEEE80211_KEY_IGTK) ||
         k->k_cipher != IEEE80211_CIPHER_CCMP) {
         /* See comment about other ciphers above. */
         ieee80211_delete_key(ic, ni, k);


### PR DESCRIPTION
Add 11w protected management frames support to `iwn` and `iwm`.
IGTK is installed using sw crypto. It appears `iwx` is using hw crypto.  I don't have card using `iwx`, so I haven't enabled IEEE80211_C_MFP for it.

Add support for WPA HMAC-SHA256 in AirportItlwm and itlwm.
There are bug fixes in the ieee80211_kdf which calculated the wrong key when used for WPA HMAC-SHA256.

I've tested this change using AC 9560, N 6205, and targeting AP running OpenWrt 21.02.0. The Encryption is set to WPA2-PSK/WPA3-SAE mixed mode. The 802.11w Management Frame Protection is set to Optional or Required.
