### PR TITLE
Fix incorrect abs macro

### DIFF
--- a/itl80211/linux/kernel.h
+++ b/itl80211/linux/kernel.h
@@ -253,6 +253,10 @@ static inline int atomic_inc_and_test(volatile SInt32 * addr)
 #define atomic_inc(v) OSIncrementAtomic(v)
 #define atomic_dec(v) OSDecrementAtomic(v)
 
-#define abs(N) ((N<0)?(-N):(N))
+#if __has_builtin(__builtin_abs)
+#define abs(N) __builtin_abs((N))
+#else
+#define abs(N) (((N)<0)?-(N):(N))
+#endif /* __has_builtin(__builtin_abs) */
 
 #endif /* kernel_h */

--- a/itlwm/hal_iwn/ItlIwn.cpp
+++ b/itlwm/hal_iwn/ItlIwn.cpp
@@ -66,7 +66,6 @@ int iwn_debug = 1;
 #define DPRINTFN(n, x)    do { ; } while (0)
 #endif
 
-#define abs(N) ((N<0)?(-N):(N))
 #define M_DEVBUF 2
 
 #ifdef DELAY


### PR DESCRIPTION
I noticed there is an issue during negotiate vht channels. If both the ap and station support 160mhz, only channels 36,40,44,48,100,104,108,112 can successfully negotiate as 160mhz. If the ap is configured as channels 52,56,60,64,116,120,124,128, the result is 20mhz.

It appears the incorrect `abs` macro cause the vht negotiate think certain channel is 80+80 which should be 160. The intel cards don't support 80+80 and thus the driver treat them as 20mhz.

The fix is to correct the `abs` macro and also use `__builtin_abs` if available