### PR TITLE
Support PCIe over Thunderbolt

### DIFF
--- a/AirportItlwm/AirportItlwm-Monterey-Info.plist
+++ b/AirportItlwm/AirportItlwm-Monterey-Info.plist
@@ -34,6 +34,8 @@
 			<integer>2000</integer>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
+			<key>IOPCITunnelCompatible</key>
+			<true/>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/AirportItlwm/AirportItlwm-Ventura-Info.plist
+++ b/AirportItlwm/AirportItlwm-Ventura-Info.plist
@@ -34,6 +34,8 @@
 			<integer>2000</integer>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
+			<key>IOPCITunnelCompatible</key>
+			<true/>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/AirportItlwm/Info.plist
+++ b/AirportItlwm/Info.plist
@@ -34,6 +34,8 @@
 			<integer>2000</integer>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
+			<key>IOPCITunnelCompatible</key>
+			<true/>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/itlwm/Info.plist
+++ b/itlwm/Info.plist
@@ -36,6 +36,8 @@
 			<string>IOPCIDevice</string>
 			<key>IOUserClientClass</key>
 			<string>ItlNetworkUserClient</string>
+			<key>IOPCITunnelCompatible</key>
+			<true/>
 			<key>WiFiConfig</key>
 			<dict>
 				<key>WiFi_1</key>


### PR DESCRIPTION
Closes https://github.com/OpenIntelWireless/itlwm/issues/807
With this added the only thing that does not work seems to be hotplugging. It's up to the dev wether you want to implement that, this addition only allows the driver to work over a Thunderbolt link.