### PR TITLE
Really fix airport_up_time

### DIFF
--- a/itl80211/openbsd/net80211/ieee80211.h
+++ b/itl80211/openbsd/net80211/ieee80211.h
@@ -2155,9 +2155,8 @@ struct ieee80211_wme_info {
 static inline uint64_t airport_up_time()
 {
     struct timeval tv;
-    
     microuptime(&tv);
-    return ((0x10624DD3LL * tv.tv_usec) >> 0x3F) + (0x10624DD3LL * tv.tv_usec >> 0x26) + tv.tv_sec * 1000LL;
+    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
 #endif
 


### PR DESCRIPTION
`0x10624DD3LL` is just a constant used for optimized division by 1000: http://flaviojslab.blogspot.com/2008/02/integer-division.html
There is no need to write it in code, because the compiler does constant division optimization by itself.
Here is the assembly code that I get after compiling my variant:
```asm
__ZL15airport_up_timev:
00000000000149e0        pushq   %rbp
00000000000149e1        movq    %rsp, %rbp
00000000000149e4        subq    $0x20, %rsp
00000000000149e8        leaq    -0x10(%rbp), %rdi
00000000000149ec        xorl    %esi, %esi
00000000000149ee        movl    $0x10, %edx
00000000000149f3        callq   _memset
00000000000149f8        movq    $0x0, -0x18(%rbp)
0000000000014a00        leaq    -0x10(%rbp), %rdi
0000000000014a04        callq   _microuptime
0000000000014a09        imull   $0x10624dd3, -0x8(%rbp), %eax   ## imm = 0x10624DD3
0000000000014a10        movl    %eax, %eax
0000000000014a12        movq    %rax, -0x18(%rbp)
0000000000014a16        movq    -0x18(%rbp), %rax
0000000000014a1a        shrq    $0x3f, %rax
0000000000014a1e        movq    -0x18(%rbp), %rcx
0000000000014a22        shrq    $0x26, %rcx
0000000000014a26        addq    %rcx, %rax
0000000000014a29        imulq   $0x3e8, -0x10(%rbp), %rcx       ## imm = 0x3E8
0000000000014a31        addq    %rcx, %rax
0000000000014a34        addq    $0x20, %rsp
0000000000014a38        popq    %rbp
0000000000014a39        retq
0000000000014a3a        nopw    (%rax,%rax)
```