### PR TITLE
Resolve GitHub Action deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '5'
 
@@ -64,9 +64,8 @@ jobs:
         git log -"5" --format="- %H %s" | sed '/^$/d' >> ReleaseNotes.md
 
     - name: Delete Old Prerelease
-      uses: dev-drprasad/delete-tag-and-release@v0.2.1
-      with:
-        tag_name: ${{ env.OLD_PRE_TAG }}
+      run: |
+        gh release delete ${{ env.OLD_PRE_TAG }} --cleanup-tag
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Also use `gh` command to delete old tag since `dev-drprasad/delete-tag-and-release` is deprecating soon

REF: https://github.com/dev-drprasad/delete-tag-and-release?tab=readme-ov-file#----warning---this-github-action-will-no-longer-be-maintained----