### PR TITLE
AirportItlwm: report Link Quality via Skywalk setLQM to fix iServices on macOS 14.4+

### DIFF
--- a/AirportItlwm/AirportItlwmV2.cpp
+++ b/AirportItlwm/AirportItlwmV2.cpp
@@ -86,7 +86,45 @@ void AirportItlwm::watchdogAction(IOTimerEventSource *timer)
 {
     struct _ifnet *ifp = &fHalService->get80211Controller()->ic_ac.ac_if;
     (*ifp->if_watchdog)(ifp);
+    updateLQMIfChanged();
     watchdogTimer->setTimeoutMS(kWatchDogTimerPeriod);
+}
+
+// Compute and report Link Quality Metric. Replaces deprecated setLinkQualityMetric
+// path on Sonoma 14.4+ Skywalk schema. SCDynamicStore key
+// State:/Network/Interface/<if>/LinkQuality must be >= 11 for apsd /
+// PCInterfaceUsabilityMonitor to consider the interface usable, otherwise the
+// entire iServices stack (iMessage / FaceTime / AirDrop) refuses to use WiFi.
+void AirportItlwm::updateLQMIfChanged()
+{
+    if (!fNetIf || !fHalService) {
+        return;
+    }
+    struct ieee80211com *ic = fHalService->get80211Controller();
+    if (!ic || ic->ic_state != IEEE80211_S_RUN) {
+        return;  // not associated; link-state mechanism signals unusable separately
+    }
+    // Snapshot ic_bss to a local — ieee80211 layer can clear it from another
+    // workloop between our check and deref.
+    struct ieee80211_node *ni = ic->ic_bss;
+    if (!ni) {
+        return;
+    }
+    // ni_rssi is normalized 0..(IWM_MAX_DBM - IWM_MIN_DBM)
+    // i.e. 0 = -100 dBm, 67 = -33 dBm.
+    int rssi_norm = ni->ni_rssi;
+    unsigned long long lq;
+    if (rssi_norm >= 30) {
+        lq = 100;                // >= -70 dBm: excellent
+    } else if (rssi_norm >= 15) {
+        lq = 50;                 // >= -85 dBm: mediocre
+    } else {
+        lq = 25;                 // weak; still > iServices threshold (11)
+    }
+    if (lq != fLastReportedLQM) {
+        fLastReportedLQM = lq;
+        fNetIf->setLQM(lq);
+    }
 }
 
 void AirportItlwm::fakeScanDone(OSObject *owner, IOTimerEventSource *sender)
@@ -102,6 +140,7 @@ bool AirportItlwm::init(OSDictionary *properties)
     bool ret = super::init(properties);
     awdlSyncEnable = true;
     power_state = 0;
+    fLastReportedLQM = 0;
     memset(geo_location_cc, 0, sizeof(geo_location_cc));
     return ret;
 }
@@ -478,7 +517,6 @@ setLinkStatus(UInt32 status, const IONetworkMedium * activeMedium, UInt64 speed,
             bsdInterface->startOutputThread();
 #endif
             getCommandGate()->runAction(setLinkStateGated, (void *)kIO80211NetworkLinkUp, (void *)0);
-//            fNetIf->setLinkQualityMetric(100);
         } else if (!(status & kIONetworkLinkNoNetworkChange)) {
 #ifdef __PRIVATE_SPI__
             bsdInterface->stopOutputThread();
@@ -503,8 +541,10 @@ setLinkStateGated(OSObject *target, void *arg0, void *arg1, void *arg2, void *ar
     that->fNetIf->postMessage(APPLE80211_M_SSID_CHANGED, NULL, 0, false);
     if ((IO80211LinkState)(uint64_t)arg0 == kIO80211NetworkLinkUp) {
         that->fNetIf->reportLinkStatus(3, 0x80);
+        that->updateLQMIfChanged();
     } else {
         that->fNetIf->reportLinkStatus(1, 0);
+        that->fLastReportedLQM = 0;
     }
     that->bsdInterface->setLinkState((IO80211LinkState)(uint64_t)arg0);
     return ret;

--- a/AirportItlwm/AirportItlwmV2.hpp
+++ b/AirportItlwm/AirportItlwmV2.hpp
@@ -99,7 +99,8 @@ public:
                                UInt64                  speed        = 0,
                                OSData *                data         = 0) override;
     static IOReturn setLinkStateGated(OSObject *target, void *arg0, void *arg1, void *arg2, void *arg3);
-    
+    void updateLQMIfChanged();
+
     static IOReturn tsleepHandler(OSObject* owner, void* arg0 = 0, void* arg1 = 0, void* arg2 = 0, void* arg3 = 0);
     static void eventHandler(struct ieee80211com *, int, void *);
     IOReturn enableAdapter(IONetworkInterface *netif);
@@ -206,6 +207,7 @@ public:
     IO80211SkywalkInterface *fNetIf;
     IOWorkLoop *fWatchdogWorkLoop;
     ItlHalService *fHalService;
+    unsigned long long fLastReportedLQM;
     
     //IO80211
     uint8_t power_state;


### PR DESCRIPTION
## Summary

On macOS Sonoma 14.4 and later, AirportItlwm V2 (Skywalk) leaves
`State:/Network/Interface/<if>/LinkQuality` at the default "no signal"
value, because the `setLinkQualityMetric(100)` call from V1 was commented
out (the API was renamed when `IO80211SkywalkInterface` replaced
`IO80211Interface`) but never ported to the new
`IO80211InfraInterface::setLQM(uint64)`. As a result, the entire iServices
stack (iMessage / FaceTime / AirDrop / Continuity) refuses to use Wi-Fi:
`+[PCInterfaceUsabilityMonitor isBadLinkQuality:]` (literal threshold
`lq < 11`) marks the interface unusable, and `apsd._connectStreamWithInterfacePreference:`
rejects every interface in the APNS path.

This PR ports link-quality reporting to the new path.

## What changed

`AirportItlwm/AirportItlwmV2.cpp` and `.hpp`:

- New helper `updateLQMIfChanged()` that maps the current `ni_rssi` to one
  of three tiers (100 / 50 / 25) and calls
  `IO80211InfraInterface::setLQM(uint64)` (resolved via virtual dispatch
  on `IO80211SkywalkInterface*`) only when the tier changes. The lowest
  tier (25) deliberately stays above the iServices threshold of 11 so
  that weak-but-recoverable links don't break iMessage on Hackintosh
  systems without cellular fallback.
- Hook into the existing 1 Hz `watchdogAction` so that signal degradation
  during a session is reflected.
- Call from the `setLinkStateGated` link-up branch so the value
  propagates immediately on association rather than waiting up to 1 s
  for the watchdog tick.
- Reset the cached value to 0 on link-down so the next link-up always
  re-reports, even if the freshly-computed value happens to match the
  cache.

## Defensive checks

- Initialize `fLastReportedLQM = 0` in `init()` —
  `OSDeclareDefaultStructors` only zero-initializes `OSObject` base
  members, leaving derived ivars with uninitialized memory; the first
  cache-compare could spuriously match one of {0, 25, 50, 100} and
  skip the initial `setLQM` call.
- Early-return when not associated (`ic_state != IEEE80211_S_RUN`) so
  we don't write a bogus "good" LQ to SCDynamicStore before the link is
  actually up.
- Snapshot `ic_bss` to a local — the ieee80211 layer can clear it from
  another workloop between the null check and the `ni_rssi` deref.
- Null-check `fHalService` — `releaseAll()` releases it before
  cancelling the watchdog timer, so a tick already in flight on
  `fWatchdogWorkLoop` could otherwise observe a NULL `fHalService` and
  crash on `get80211Controller()`. Reordering `releaseAll()` is out of
  scope for this PR; the cheap defensive check prevents this code path
  from making the existing race observable.

## ABI / compatibility

`IO80211SkywalkInterface.h` in this repository already declares `setLQM`
unconditionally (line 108 on master), and `IO80211InfraInterface`
provides the working override in `IO80211Family.kext`. No new external
symbol is introduced — the binary's undefined-symbol set against
`__ZN21IO80211InfraInterface6setLQMEy` is unchanged from existing
2.3.0/2.4.0 builds. So this is safe to ship for all macOS targets the
project currently supports; on macOS versions where `IO80211Family`
provides only the empty `IO80211SkywalkInterface::setLQM` stub at that
vtable slot, the call is a no-op rather than a crash.

## Verification (Intel AX201, macOS 14.8.5)

Before:

- `scutil` `show State:/Network/Interface/en0/LinkQuality` ⇒ `-2`
- `apsd` log: `Push is connected? NO networkIsHistoricallyUsable? YES isBadLQ? YES`
- iMessage / FaceTime fail to register

After this patch:

- `scutil` `show State:/Network/Interface/en0/LinkQuality` ⇒ `100`
- `apsd` log: `Push is connected? NO networkIsHistoricallyUsable? YES isBadLQ? NO`
- `apsd` log: `courier <private>: Sending outgoing message N onInterface: NonCellular. Connected on 1 interfaces.`
- iMessage / FaceTime / AirDrop work after a single reboot.

## Test plan

- [x] Builds against MacKernelSDK on `macos-latest` runner for all eight
      macOS targets (Big Sur through Sonoma 14.4) via the existing CI.
- [x] Verified on real hardware: HP EliteBook x360 1030 G3 (Intel AX201),
      Sonoma 14.8.5, OpenCore boot.
- [x] iServices recovery confirmed via APNS courier log + iMessage
      send/receive after reboot.
- [ ] Reviewer to verify on additional Intel chipset (iwn / iwm Gen 1)
      to confirm `ni_rssi` units are normalized identically across HALs.