### PR TITLE
Fix Airplay in Mac OS Ventura when using AX210NGW

### DIFF
--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -1454,7 +1454,7 @@ IOReturn AirportItlwm::
 setVIRTUAL_IF_CREATE(OSObject *object, struct apple80211_virt_if_create_data* data)
 {
     // From Ventura, the virtual interface sequence has channged, now temporary disabled the virtual interface creation because it is no functionality. This fix the issue of delaying start time of associating to AP.
-#if __IO80211_TARGET >= __MAC_13_0
+#if 0 // TEST: re-enable virtual interface creation on Ventura
     return kIOReturnUnsupported;
 #else
     struct ether_addr addr;
@@ -1489,7 +1489,14 @@ setVIRTUAL_IF_CREATE(OSObject *object, struct apple80211_virt_if_create_data* da
         chann.version = 1;
         chann.flags = APPLE80211_C_FLAG_5GHZ | APPLE80211_C_FLAG_ACTIVE | APPLE80211_C_FLAG_80MHZ;
         setInfraChannel(&chann);
+        if (!inf->attach(this)) {
+            XYLog("%s failed to attach AWDL interface to controller\n", __FUNCTION__);
+            inf->release();
+            return kIOReturnError;
+        }
+
         fAWDLInterface = inf;
+        inf->registerService(); // TEST: attach + publish AWDL to IOService/CoreWiFi
     } else {
         XYLog("%s unhandled virtual interface role type: %d\n", __FUNCTION__, data->role);
         return kIOReturnError;

--- a/AirportItlwm/AirportSTAIOCTL.cpp
+++ b/AirportItlwm/AirportSTAIOCTL.cpp
@@ -1453,10 +1453,6 @@ getSCAN_RESULT(OSObject *object, struct apple80211_scan_result **sr)
 IOReturn AirportItlwm::
 setVIRTUAL_IF_CREATE(OSObject *object, struct apple80211_virt_if_create_data* data)
 {
-    // From Ventura, the virtual interface sequence has channged, now temporary disabled the virtual interface creation because it is no functionality. This fix the issue of delaying start time of associating to AP.
-#if 0 // TEST: re-enable virtual interface creation on Ventura
-    return kIOReturnUnsupported;
-#else
     struct ether_addr addr;
     struct apple80211_channel chann;
     XYLog("%s role=%d, bsd_name=%s, mac=%s, unk1=%d\n", __FUNCTION__, data->role, data->bsd_name,
@@ -1496,13 +1492,12 @@ setVIRTUAL_IF_CREATE(OSObject *object, struct apple80211_virt_if_create_data* da
         }
 
         fAWDLInterface = inf;
-        inf->registerService(); // TEST: attach + publish AWDL to IOService/CoreWiFi
+        inf->registerService();
     } else {
         XYLog("%s unhandled virtual interface role type: %d\n", __FUNCTION__, data->role);
         return kIOReturnError;
     }
     return kIOReturnSuccess;
-#endif
 }
 
 IOReturn AirportItlwm::


### PR DESCRIPTION
Re-enabled Ventura’s AWDL virtual-interface creation and then properly attached the AWDL interface to the AirportItlwm IOService tree and registered it. That allowed CoreWiFi to recognize awdl0, which restored Screen Mirroring/AirPlay discovery and connection. Tested with AX210NGW and Latitude 7490. Contains AI generated code.